### PR TITLE
PTPP-836 Add safeNumber to OrganisationDetails

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
@@ -34,7 +34,8 @@ object OrgType extends Enumeration {
 case class OrganisationDetails(
   isBasedInUk: Option[Boolean] = None,
   organisationType: Option[OrgType] = None,
-  businessRegisteredAddress: Option[Address] = None
+  businessRegisteredAddress: Option[Address] = None,
+  safeNumber: Option[String] = None
 )
 
 object OrganisationDetails {


### PR DESCRIPTION
A `SafeNumber` may be returned by the relevant GRS microservice, if a
legal entity has been successfuly registered by the GRS service.