### PR TITLE
PPTP-994 Make NRS submissinId/failureReason available to FE

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/EISResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/EISResponse.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
+
+trait EISResponse

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/EISSubscriptionCreateSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/EISSubscriptionCreateSuccessfulResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
+
+import java.time.ZonedDateTime
+
+trait EISSubscriptionCreateSuccessfulResponse extends EISResponse {
+  val pptReference: String
+  val processingDate: ZonedDateTime
+  val formBundleNumber: String
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateWithNrsFailureResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateWithNrsFailureResponse.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.nrs.NrsFailureResponse
+
+import java.time.ZonedDateTime
+
+case class SubscriptionCreateWithNrsFailureResponse(
+  override val pptReference: String,
+  override val processingDate: ZonedDateTime,
+  override val formBundleNumber: String,
+  override val nrsFailureReason: String
+) extends EISSubscriptionCreateSuccessfulResponse with NrsFailureResponse
+
+object SubscriptionCreateWithNrsFailureResponse {
+
+  implicit val format: OFormat[SubscriptionCreateWithNrsFailureResponse] =
+    Json.format[SubscriptionCreateWithNrsFailureResponse]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateWithNrsSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateWithNrsSuccessfulResponse.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.nrs.NrsSuccessfulResponse
+
+import java.time.ZonedDateTime
+
+case class SubscriptionCreateWithNrsSuccessfulResponse(
+  override val pptReference: String,
+  override val processingDate: ZonedDateTime,
+  override val formBundleNumber: String,
+  override val nrSubmissionId: String
+) extends EISSubscriptionCreateSuccessfulResponse with NrsSuccessfulResponse
+
+object SubscriptionCreateWithNrsSuccessfulResponse {
+
+  implicit val format: OFormat[SubscriptionCreateWithNrsSuccessfulResponse] =
+    Json.format[SubscriptionCreateWithNrsSuccessfulResponse]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/nrs/NrsFailureResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/nrs/NrsFailureResponse.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.nrs
+
+trait NrsFailureResponse extends NrsResponse {
+  val nrsFailureReason: String
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/nrs/NrsResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/nrs/NrsResponse.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.nrs
+
+trait NrsResponse

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/nrs/NrsSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/nrs/NrsSuccessfulResponse.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.nrs
+
+trait NrsSuccessfulResponse extends NrsResponse {
+  val nrSubmissionId: String
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
@@ -20,21 +20,28 @@ import play.api.Logger
 import play.api.libs.json.Json.toJson
 import play.api.libs.json._
 import play.api.mvc._
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.SubscriptionsConnector
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{
   Subscription,
-  SubscriptionCreateSuccessfulResponse
+  SubscriptionCreateSuccessfulResponse,
+  SubscriptionCreateWithNrsFailureResponse,
+  SubscriptionCreateWithNrsSuccessfulResponse
 }
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatusResponse
-import uk.gov.hmrc.plasticpackagingtaxregistration.controllers.actions.Authenticator
+import uk.gov.hmrc.plasticpackagingtaxregistration.controllers.actions.{
+  Authenticator,
+  AuthorizedRequest
+}
 import uk.gov.hmrc.plasticpackagingtaxregistration.controllers.response.JSONResponses
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.RegistrationRequest
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.nrs.NonRepudiationSubmissionAccepted
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.{Registration, RegistrationRequest}
 import uk.gov.hmrc.plasticpackagingtaxregistration.repositories.RegistrationRepository
 import uk.gov.hmrc.plasticpackagingtaxregistration.services.nrs.NonRepudiationService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class SubscriptionController @Inject() (
@@ -62,17 +69,63 @@ class SubscriptionController @Inject() (
         val pptSubscription = request.body.toRegistration(request.pptId)
         val eisSubscription = Subscription(pptSubscription)
         logPayload("PPT Subscription: ", eisSubscription)
-        subscriptionsConnector.submitSubscription(safeNumber, eisSubscription).map {
-          case response @ SubscriptionCreateSuccessfulResponse(pptReference, processingDate, _) =>
-            nonRepudiationService.submitNonRepudiation(toJson(pptSubscription).toString,
-                                                       processingDate,
-                                                       pptReference,
-                                                       request.body.userHeaders.getOrElse(Map.empty)
-            )
-            repository.delete(request.pptId)
-            Ok(response)
+        subscriptionsConnector.submitSubscription(safeNumber, eisSubscription).flatMap {
+          case eisResponse @ SubscriptionCreateSuccessfulResponse(_, _, _) =>
+            handleNrsRequest(request, pptSubscription, eisResponse)
+              .andThen { case _ => repository.delete(request.pptId) }
+
         }
     }
+
+  private def handleNrsRequest(
+    request: AuthorizedRequest[RegistrationRequest],
+    pptSubscription: Registration,
+    eisResponse: SubscriptionCreateSuccessfulResponse
+  )(implicit hc: HeaderCarrier): Future[Result] =
+    submitToNrs(request, pptSubscription, eisResponse).map {
+      case NonRepudiationSubmissionAccepted(nrSubmissionId) =>
+        handleNrsSuccess(eisResponse, nrSubmissionId)
+    }.recoverWith {
+      case exception: Exception =>
+        handleNrsFailure(eisResponse, exception)
+    }
+
+  private def submitToNrs(
+    request: AuthorizedRequest[RegistrationRequest],
+    pptSubscription: Registration,
+    eisResponse: SubscriptionCreateSuccessfulResponse
+  )(implicit hc: HeaderCarrier): Future[NonRepudiationSubmissionAccepted] =
+    nonRepudiationService.submitNonRepudiation(toJson(pptSubscription).toString,
+                                               eisResponse.processingDate,
+                                               eisResponse.pptReference,
+                                               request.body.userHeaders.getOrElse(Map.empty)
+    )
+
+  private def handleNrsFailure(
+    eisResponse: SubscriptionCreateSuccessfulResponse,
+    exception: Exception
+  ): Future[Result] =
+    Future.successful(
+      Ok(
+        SubscriptionCreateWithNrsFailureResponse(eisResponse.pptReference,
+                                                 eisResponse.processingDate,
+                                                 eisResponse.formBundleNumber,
+                                                 exception.getMessage
+        )
+      )
+    )
+
+  private def handleNrsSuccess(
+    eisResponse: SubscriptionCreateSuccessfulResponse,
+    nrSubmissionId: String
+  ): Result =
+    Ok(
+      SubscriptionCreateWithNrsSuccessfulResponse(eisResponse.pptReference,
+                                                  eisResponse.processingDate,
+                                                  eisResponse.formBundleNumber,
+                                                  nrSubmissionId
+      )
+    )
 
   private def logPayload[T](prefix: String, payload: T)(implicit wts: Writes[T]): T = {
     logger.debug(s"$prefix payload: ${toJson(payload)}")


### PR DESCRIPTION
As part of the NRS work we need to CiP/TxM audit the `nrSubmissionId` or
the NRS failure reason.

This is passed to the FE, where the CiP audit currently lives.