### PR TITLE
PPTP-1205 : Alert of Duplicate Subscriptions

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateFailureResponseWithStatusCode.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateFailureResponseWithStatusCode.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class SubscriptionCreateFailureResponseWithStatusCode(
+  failureResponse: SubscriptionCreateFailureResponse,
+  statusCode: Int
+) extends SubscriptionCreateResponse
+
+object SubscriptionCreateFailureResponseWithStatusCode {
+
+  implicit val format: OFormat[SubscriptionCreateFailureResponseWithStatusCode] =
+    Json.format[SubscriptionCreateFailureResponseWithStatusCode]
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/unit/MockConnectors.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/unit/MockConnectors.scala
@@ -18,13 +18,17 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.base.unit
 
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.BDDMockito.`given`
-import org.mockito.Mockito.{doAnswer, reset, when}
+import org.mockito.Mockito.{reset, when}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.{BeforeAndAfterEach, Suite}
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.SubscriptionCreateSuccessfulResponse
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{
+  SubscriptionCreateFailureResponse,
+  SubscriptionCreateFailureResponseWithStatusCode,
+  SubscriptionCreateResponse,
+  SubscriptionCreateSuccessfulResponse
+}
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatusResponse
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.parsers.TaxEnrolmentsHttpParser
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.parsers.TaxEnrolmentsHttpParser.{
@@ -60,9 +64,16 @@ trait MockConnectors extends MockitoSugar with BeforeAndAfterEach {
 
   protected def mockGetSubscriptionSubmitFailure(
     ex: Exception
-  ): OngoingStubbing[Future[SubscriptionCreateSuccessfulResponse]] =
+  ): OngoingStubbing[Future[SubscriptionCreateResponse]] =
     when(mockSubscriptionsConnector.submitSubscription(any(), any())(any()))
       .thenThrow(ex)
+
+  protected def mockGetSubscriptionSubmitFailure(
+    failedResponse: SubscriptionCreateFailureResponseWithStatusCode
+  ): OngoingStubbing[Future[SubscriptionCreateResponse]] =
+    when(mockSubscriptionsConnector.submitSubscription(any(), any())(any())).thenReturn(
+      Future.successful(failedResponse)
+    )
 
   protected def mockGetSubscriptionStatus(
     subscription: SubscriptionStatusResponse
@@ -73,7 +84,7 @@ trait MockConnectors extends MockitoSugar with BeforeAndAfterEach {
 
   protected def mockGetSubscriptionCreate(
     subscription: SubscriptionCreateSuccessfulResponse
-  ): OngoingStubbing[Future[SubscriptionCreateSuccessfulResponse]] =
+  ): OngoingStubbing[Future[SubscriptionCreateResponse]] =
     when(mockSubscriptionsConnector.submitSubscription(any(), any())(any())).thenReturn(
       Future.successful(subscription)
     )

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnectorISpec.scala
@@ -25,7 +25,11 @@ import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.plasticpackagingtaxregistration.base.Injector
 import uk.gov.hmrc.plasticpackagingtaxregistration.base.it.ConnectorISpec
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.EISError
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.SubscriptionCreateSuccessfulResponse
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{
+  SubscriptionCreateFailureResponse,
+  SubscriptionCreateFailureResponseWithStatusCode,
+  SubscriptionCreateSuccessfulResponse
+}
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.ETMPSubscriptionStatus.NO_FORM_BUNDLE_FOUND
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatusResponse
 
@@ -184,9 +188,19 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
 
         stubSubscriptionSubmissionFailure(httpStatus = Status.BAD_REQUEST, errors = errors)
 
-        intercept[UpstreamErrorResponse] {
-          await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
-        }.statusCode mustBe Status.BAD_REQUEST
+        val resp = await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
+
+        resp mustBe SubscriptionCreateFailureResponseWithStatusCode(
+          SubscriptionCreateFailureResponse(
+            List(
+              EISError("INVALID_IDVALUE",
+                       "Submission has not passed validation. Invalid parameter idValue."
+              )
+            )
+          ),
+          400
+        )
+
         getTimer(pptSubscriptionSubmissionTimer).getCount mustBe 1
       }
 
@@ -200,9 +214,19 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
 
         stubSubscriptionSubmissionFailure(httpStatus = Status.CONFLICT, errors = errors)
 
-        intercept[UpstreamErrorResponse] {
-          await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
-        }.statusCode mustBe Status.CONFLICT
+        val resp = await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
+
+        resp mustBe SubscriptionCreateFailureResponseWithStatusCode(
+          SubscriptionCreateFailureResponse(
+            List(
+              EISError("DUPLICATE_SUBMISSION",
+                       "The remote endpoint has indicated that duplicate submission acknowledgment reference."
+              )
+            )
+          ),
+          409
+        )
+
         getTimer(pptSubscriptionSubmissionTimer).getCount mustBe 1
       }
 
@@ -216,9 +240,19 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
 
         stubSubscriptionSubmissionFailure(httpStatus = Status.UNPROCESSABLE_ENTITY, errors = errors)
 
-        intercept[UpstreamErrorResponse] {
-          await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
-        }.statusCode mustBe Status.UNPROCESSABLE_ENTITY
+        val resp = await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
+
+        resp mustBe SubscriptionCreateFailureResponseWithStatusCode(
+          SubscriptionCreateFailureResponse(
+            List(
+              EISError("ACTIVE_SUBSCRIPTION_EXISTS",
+                       "The remote endpoint has indicated that Business Partner already has active subscription for this regime."
+              )
+            )
+          ),
+          422
+        )
+
         getTimer(pptSubscriptionSubmissionTimer).getCount mustBe 1
       }
 
@@ -233,9 +267,15 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
                                           errors = errors
         )
 
-        intercept[UpstreamErrorResponse] {
-          await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
-        }.statusCode mustBe Status.INTERNAL_SERVER_ERROR
+        val resp = await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
+
+        resp mustBe SubscriptionCreateFailureResponseWithStatusCode(
+          SubscriptionCreateFailureResponse(
+            List(EISError("NO_DATA_FOUND", "Dependent systems are currently not responding."))
+          ),
+          500
+        )
+
         getTimer(pptSubscriptionSubmissionTimer).getCount mustBe 1
       }
 
@@ -248,9 +288,15 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
 
         stubSubscriptionSubmissionFailure(httpStatus = Status.BAD_GATEWAY, errors = errors)
 
-        intercept[UpstreamErrorResponse] {
-          await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
-        }.statusCode mustBe Status.BAD_GATEWAY
+        val resp = await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
+
+        resp mustBe SubscriptionCreateFailureResponseWithStatusCode(
+          SubscriptionCreateFailureResponse(
+            List(EISError("BAD_GATEWAY", "Dependent systems are currently not responding."))
+          ),
+          502
+        )
+
         getTimer(pptSubscriptionSubmissionTimer).getCount mustBe 1
       }
 
@@ -263,9 +309,15 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
 
         stubSubscriptionSubmissionFailure(httpStatus = Status.SERVICE_UNAVAILABLE, errors = errors)
 
-        intercept[UpstreamErrorResponse] {
-          await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
-        }.statusCode mustBe Status.SERVICE_UNAVAILABLE
+        val resp = await(connector.submitSubscription(safeNumber, ukLimitedCompaySubscription))
+
+        resp mustBe SubscriptionCreateFailureResponseWithStatusCode(
+          SubscriptionCreateFailureResponse(
+            List(EISError("SERVICE_UNAVAILABLE", "Dependent systems are currently not responding."))
+          ),
+          503
+        )
+
         getTimer(pptSubscriptionSubmissionTimer).getCount mustBe 1
       }
 


### PR DESCRIPTION
We need to inform the user of duplicate subscription failures when we attempt to create the PPT subscription. We communicate EIS subscription failure responses to the registration front end so that it can decide how to deal with them.

Associated FE change: 

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
