### PR TITLE
BAU : Disable the JUnit XML report plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(scoverageSettings)
 
+  .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)
 
 lazy val scoverageSettings: Seq[Setting[_]] = Seq(
   coverageExcludedPackages := List(


### PR DESCRIPTION
There is a known issue where JUnit reporters can mangle test output files when jobs are run in parallel.


