### PR TITLE
PPTP-1211 - simplify SubscriptionStatusResponse

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/ETMPSubscriptionStatusResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/ETMPSubscriptionStatusResponse.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus
+
+import play.api.libs.json.{Json, OFormat}
+import ETMPSubscriptionStatus.Status
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.EISError
+import ETMPSubscriptionChannel.SubscriptionChannel
+
+case class ETMPSubscriptionStatusResponse(
+  subscriptionStatus: Option[Status] = None,
+  idType: Option[String] = None,
+  idValue: Option[String] = None,
+  channel: Option[SubscriptionChannel] = None,
+  failures: Option[Seq[EISError]] = None
+)
+
+object ETMPSubscriptionStatusResponse {
+
+  implicit val format: OFormat[ETMPSubscriptionStatusResponse] =
+    Json.format[ETMPSubscriptionStatusResponse]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatus.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatus.scala
@@ -18,24 +18,13 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscr
 
 import play.api.libs.json.{Format, Reads, Writes}
 
-object ETMPSubscriptionStatus extends Enumeration {
+object SubscriptionStatus extends Enumeration {
   type Status = Value
-  val NO_FORM_BUNDLE_FOUND: Value     = Value
-  val SUCCESSFUL: Value               = Value
-  val REG_FORM_RECEIVED: Value        = Value
-  val SENT_TO_DS: Value               = Value
-  val DS_OUTCOME_IN_PROGRESS: Value   = Value
-  val REJECTED: Value                 = Value
-  val IN_PROCESSING: Value            = Value
-  val CREATE_FAILED: Value            = Value
-  val WITHDRAWAL: Value               = Value
-  val SENT_TO_RCM: Value              = Value
-  val APPROVED_WITH_CONDITIONS: Value = Value
-  val REVOKED: Value                  = Value
-  val DE_REGISTERED: Value            = Value("DE-REGISTERED")
-  val CONTRACT_OBJECT_INACTIVE: Value = Value
+  val SUBSCRIBED: Value     = Value
+  val NOT_SUBSCRIBED: Value = Value
+  val UNKNOWN: Value        = Value
 
   implicit val format: Format[Status] =
-    Format(Reads.enumNameReads(ETMPSubscriptionStatus), Writes.enumNameWrites)
+    Format(Reads.enumNameReads(SubscriptionStatus), Writes.enumNameWrites)
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatusResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatusResponse.scala
@@ -41,7 +41,12 @@ object SubscriptionStatusResponse {
       case _                          => UNKNOWN
     }
 
-    SubscriptionStatusResponse(status, etmpResponse.idValue)
+    val pptRef = etmpResponse.idType match {
+      case Some("ZPPT") => etmpResponse.idValue
+      case _            => None
+    }
+
+    SubscriptionStatusResponse(status, pptRef)
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatusResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatusResponse.scala
@@ -17,18 +17,31 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus
 
 import play.api.libs.json.{Json, OFormat}
-import ETMPSubscriptionStatus.SubscriptionStatus
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.EISError
-import ETMPSubscriptionChannel.SubscriptionChannel
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.ETMPSubscriptionStatus.{
+  NO_FORM_BUNDLE_FOUND,
+  SUCCESSFUL
+}
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatus.{
+  NOT_SUBSCRIBED,
+  SUBSCRIBED,
+  Status,
+  UNKNOWN
+}
 
-case class SubscriptionStatusResponse(
-  subscriptionStatus: Option[SubscriptionStatus] = None,
-  idType: Option[String] = None,
-  idValue: Option[String] = None,
-  channel: Option[SubscriptionChannel] = None,
-  failures: Option[Seq[EISError]] = None
-)
+case class SubscriptionStatusResponse(status: Status, pptReference: Option[String] = None)
 
 object SubscriptionStatusResponse {
   implicit val format: OFormat[SubscriptionStatusResponse] = Json.format[SubscriptionStatusResponse]
+
+  def fromETMPResponse(etmpResponse: ETMPSubscriptionStatusResponse) = {
+
+    val status = etmpResponse.subscriptionStatus match {
+      case Some(NO_FORM_BUNDLE_FOUND) => NOT_SUBSCRIBED
+      case Some(SUCCESSFUL)           => SUBSCRIBED
+      case _                          => UNKNOWN
+    }
+
+    SubscriptionStatusResponse(status, etmpResponse.idValue)
+  }
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.plasticpackagingtaxregistration.controllers
 
+import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.libs.json.Json.toJson
 import play.api.libs.json._
@@ -27,7 +28,6 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscri
   SubscriptionCreateSuccessfulResponse,
   SubscriptionCreateWithEnrolmentAndNrsStatusesResponse
 }
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatusResponse
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.parsers.TaxEnrolmentsHttpParser.TaxEnrolmentsResponse
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.{
   EnrolmentConnector,
@@ -44,7 +44,6 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.repositories.RegistrationRepo
 import uk.gov.hmrc.plasticpackagingtaxregistration.services.nrs.NonRepudiationService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -63,9 +62,8 @@ class SubscriptionController @Inject() (
 
   def get(safeNumber: String): Action[AnyContent] =
     authenticator.authorisedAction(parse.default) { implicit request =>
-      subscriptionsConnector.getSubscriptionStatus(safeNumber).map {
-        response: SubscriptionStatusResponse =>
-          Ok(response)
+      subscriptionsConnector.getSubscriptionStatus(safeNumber).map { response =>
+        Ok(response)
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
@@ -16,18 +16,20 @@
 
 package uk.gov.hmrc.plasticpackagingtaxregistration.base.data
 
+import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime.now
+import java.time.format.DateTimeFormatter
+
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.EISError
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription._
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatus.NOT_SUBSCRIBED
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.{
   ETMPSubscriptionStatus,
+  ETMPSubscriptionStatusResponse,
   SubscriptionStatusResponse
 }
-
-import java.time.ZoneOffset.UTC
-import java.time.ZonedDateTime.now
-import java.time.format.DateTimeFormatter
 
 trait SubscriptionTestData {
 
@@ -40,12 +42,15 @@ trait SubscriptionTestData {
   protected val subscriptionCreate_HttpPost: FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest("POST", "/subscriptions/" + safeNumber)
 
-  protected val subscriptionStatusResponse: SubscriptionStatusResponse =
-    SubscriptionStatusResponse(subscriptionStatus =
-                                 Some(ETMPSubscriptionStatus.NO_FORM_BUNDLE_FOUND),
-                               idType = Some("ZPPT"),
-                               idValue = Some("X00000123456789")
+  protected val etmpSubscriptionStatusResponse: ETMPSubscriptionStatusResponse =
+    ETMPSubscriptionStatusResponse(subscriptionStatus =
+                                     Some(ETMPSubscriptionStatus.NO_FORM_BUNDLE_FOUND),
+                                   idType = Some("ZPPT"),
+                                   idValue = Some("X00000123456789")
     )
+
+  protected val subscriptionStatusResponse: SubscriptionStatusResponse =
+    SubscriptionStatusResponse(status = NOT_SUBSCRIBED, pptReference = Some("ZPPT"))
 
   protected val subscriptionCreateResponse: SubscriptionCreateSuccessfulResponse =
     SubscriptionCreateSuccessfulResponse(pptReference = "XMPPT123456789",

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/unit/MockConnectors.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/unit/MockConnectors.scala
@@ -24,7 +24,6 @@ import org.scalatest.{BeforeAndAfterEach, Suite}
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{
-  SubscriptionCreateFailureResponse,
   SubscriptionCreateFailureResponseWithStatusCode,
   SubscriptionCreateResponse,
   SubscriptionCreateSuccessfulResponse

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatusResponseSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscriptionStatus/SubscriptionStatusResponseSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SubscriptionStatusResponseSpec extends AnyWordSpec with Matchers {
+
+  "SubscriptionStatusResponse" should {
+    "convert from ETMPSubscriptionStatusResponse" when {
+      "ETMP status is 'NO_FORM_BUNDLE_FOUND'" in {
+        val response = SubscriptionStatusResponse.fromETMPResponse(
+          ETMPSubscriptionStatusResponse(Some(ETMPSubscriptionStatus.NO_FORM_BUNDLE_FOUND))
+        )
+        response.status mustBe SubscriptionStatus.NOT_SUBSCRIBED
+      }
+
+      "ETMP status is 'SUCCESSFUL'" in {
+        val response = SubscriptionStatusResponse.fromETMPResponse(
+          ETMPSubscriptionStatusResponse(Some(ETMPSubscriptionStatus.SUCCESSFUL))
+        )
+        response.status mustBe SubscriptionStatus.SUBSCRIBED
+      }
+
+      "ETMP status is something else" in {
+        val response = SubscriptionStatusResponse.fromETMPResponse(
+          ETMPSubscriptionStatusResponse(Some(ETMPSubscriptionStatus.DS_OUTCOME_IN_PROGRESS))
+        )
+        response.status mustBe SubscriptionStatus.UNKNOWN
+      }
+    }
+
+    "handle PPT reference" when {
+      "idValue is provided for idType 'ZPPT'" in {
+        val response = SubscriptionStatusResponse.fromETMPResponse(
+          ETMPSubscriptionStatusResponse(subscriptionStatus =
+                                           Some(ETMPSubscriptionStatus.SUCCESSFUL),
+                                         idValue = Some("PPTRef"),
+                                         idType = Some("ZPPT")
+          )
+        )
+        response.pptReference mustBe Some("PPTRef")
+      }
+
+      "idValue is provided for other idType" in {
+        val response = SubscriptionStatusResponse.fromETMPResponse(
+          ETMPSubscriptionStatusResponse(subscriptionStatus =
+                                           Some(ETMPSubscriptionStatus.SUCCESSFUL),
+                                         idValue = Some("PPTRef"),
+                                         idType = Some("XYZ")
+          )
+        )
+        response.pptReference mustBe None
+      }
+
+      "idValue is not provided" in {
+        val response = SubscriptionStatusResponse.fromETMPResponse(
+          ETMPSubscriptionStatusResponse(subscriptionStatus =
+            Some(ETMPSubscriptionStatus.SUCCESSFUL)
+          )
+        )
+        response.pptReference mustBe None
+      }
+
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionControllerSpec.scala
@@ -50,7 +50,7 @@ class SubscriptionControllerSpec
     Mockito.reset(mockRepository, mockNonRepudiationService)
     super.beforeEach()
 
-    when(mockRepository.delete(any())).thenReturn(Future.successful())
+    when(mockRepository.delete(any())).thenReturn(Future.successful(()))
   }
 
   "Get subscription status" should {


### PR DESCRIPTION
### Description of Work carried through

Create a simplified SubscriptionStatusResponse that is aligned with the needs of the FE service

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
