### PR TITLE
PPTP-1143 - new LiabilityExpectedWeight field for pre-launch

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/LiabilityDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/LiabilityDetails.scala
@@ -26,6 +26,15 @@ object LiabilityWeight {
   implicit val liabilityWeightFormat = Json.format[LiabilityWeight]
 }
 
+case class LiabilityExpectedWeight(
+  expectToExceedThresholdWeight: Option[Boolean],
+  totalKg: Option[Long]
+)
+
+object LiabilityExpectedWeight {
+  implicit val liabilityWeightExpectedFormat = Json.format[LiabilityExpectedWeight]
+}
+
 case class Date(day: Option[Int], month: Option[Int], year: Option[Int]) {
 
   val pretty: String =
@@ -39,6 +48,7 @@ object Date {
 
 case class LiabilityDetails(
   weight: Option[LiabilityWeight] = None,
+  expectedWeight: Option[LiabilityExpectedWeight] = None,
   startDate: Option[Date] = None,
   isLiable: Option[Boolean] = None,
   expectToExceedThresholdWeight: Option[Boolean] = None


### PR DESCRIPTION
### Description of Work carried through

Add new model to LiabilityDetails

Requires FE PR - https://github.com/hmrc/plastic-packaging-tax-registration-frontend/pull/179

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
