### PR TITLE
PPTP-1244 success response contains pptReferenceNumber, not pptReference

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionCreateSuccessfulResponse.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Json, OFormat}
 import java.time.ZonedDateTime
 
 case class SubscriptionCreateSuccessfulResponse(
-  pptReference: String,
+  pptReferenceNumber: String,
   processingDate: ZonedDateTime,
   formBundleNumber: String
 ) extends SubscriptionCreateResponse

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
@@ -53,7 +53,7 @@ trait SubscriptionTestData {
     SubscriptionStatusResponse(status = NOT_SUBSCRIBED, pptReference = Some("ZPPT"))
 
   protected val subscriptionCreateResponse: SubscriptionCreateSuccessfulResponse =
-    SubscriptionCreateSuccessfulResponse(pptReference = "XMPPT123456789",
+    SubscriptionCreateSuccessfulResponse(pptReferenceNumber = "XMPPT123456789",
                                          processingDate = now(UTC),
                                          formBundleNumber = "123456789"
     )

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnectorISpec.scala
@@ -162,9 +162,9 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
               aResponse()
                 .withStatus(Status.OK)
                 .withBody(
-                  Json.obj("pptReference"     -> pptReference,
-                           "processingDate"   -> subscriptionProcessingDate,
-                           "formBundleNumber" -> formBundleNumber
+                  Json.obj("pptReferenceNumber" -> pptReference,
+                           "processingDate"     -> subscriptionProcessingDate,
+                           "formBundleNumber"   -> formBundleNumber
                   ).toString
                 )
             )
@@ -175,7 +175,7 @@ class SubscriptionsConnectorISpec extends ConnectorISpec with Injector with Scal
             SubscriptionCreateSuccessfulResponse
           ]
 
-        res.pptReference mustBe pptReference
+        res.pptReferenceNumber mustBe pptReference
         res.formBundleNumber mustBe formBundleNumber
         res.processingDate mustBe ZonedDateTime.parse(subscriptionProcessingDate)
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionControllerSpec.scala
@@ -121,7 +121,7 @@ class SubscriptionControllerSpec
           status(result) must be(OK)
           val response =
             contentAsJson(result).as[SubscriptionCreateWithEnrolmentAndNrsStatusesResponse]
-          response.pptReference mustBe subscriptionCreateResponse.pptReference
+          response.pptReference mustBe subscriptionCreateResponse.pptReferenceNumber
           response.formBundleNumber mustBe subscriptionCreateResponse.formBundleNumber
           response.processingDate mustBe subscriptionCreateResponse.processingDate
           response.nrsNotifiedSuccessfully mustBe true
@@ -133,7 +133,7 @@ class SubscriptionControllerSpec
           verify(mockNonRepudiationService).submitNonRepudiation(
             ArgumentMatchers.contains(request.incorpJourneyId.get),
             any[ZonedDateTime],
-            ArgumentMatchers.eq(subscriptionCreateResponse.pptReference),
+            ArgumentMatchers.eq(subscriptionCreateResponse.pptReferenceNumber),
             ArgumentMatchers.eq(pptUserHeaders)
           )(any[HeaderCarrier])
         }
@@ -231,7 +231,7 @@ class SubscriptionControllerSpec
     status(result) must be(OK)
     val response =
       contentAsJson(result).as[SubscriptionCreateWithEnrolmentAndNrsStatusesResponse]
-    response.pptReference mustBe subscriptionCreateResponse.pptReference
+    response.pptReference mustBe subscriptionCreateResponse.pptReferenceNumber
     response.formBundleNumber mustBe subscriptionCreateResponse.formBundleNumber
     response.processingDate mustBe subscriptionCreateResponse.processingDate
     response.nrsNotifiedSuccessfully mustBe false
@@ -243,7 +243,7 @@ class SubscriptionControllerSpec
     verify(mockNonRepudiationService).submitNonRepudiation(
       ArgumentMatchers.contains(request.incorpJourneyId.get),
       any[ZonedDateTime],
-      ArgumentMatchers.eq(subscriptionCreateResponse.pptReference),
+      ArgumentMatchers.eq(subscriptionCreateResponse.pptReferenceNumber),
       ArgumentMatchers.eq(pptUserHeaders)
     )(any[HeaderCarrier])
   }


### PR DESCRIPTION
### Description of Work

Success reponse for create/update schema contains field called pptReferenceNumber, not pptReference.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
