### PR TITLE
PPTP-1150 - make PPT address line 2 non-optional

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
@@ -36,7 +36,7 @@ object AddressDetails {
     address match {
       case Some(addressDetails) =>
         AddressDetails(addressLine1 = addressDetails.addressLine1,
-                       addressLine2 = addressDetails.addressLine2.getOrElse(""),
+                       addressLine2 = addressDetails.addressLine2,
                        addressLine3 = addressDetails.addressLine3,
                        addressLine4 = Some(addressDetails.townOrCity),
                        postalCode = Some(addressDetails.postCode),

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
@@ -45,8 +45,7 @@ object BusinessCorrespondenceDetails {
         )
 
     BusinessCorrespondenceDetails(addressLine1 = businessCorrespondenceAddress.addressLine1,
-                                  addressLine2 =
-                                    businessCorrespondenceAddress.addressLine2.getOrElse(" "),
+                                  addressLine2 = businessCorrespondenceAddress.addressLine2,
                                   addressLine3 = businessCorrespondenceAddress.addressLine3,
                                   addressLine4 = Some(businessCorrespondenceAddress.townOrCity),
                                   postalCode = Some(businessCorrespondenceAddress.postCode),

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PrimaryContactDetails.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 case class Address(
   addressLine1: String,
-  addressLine2: Option[String] = None,
+  addressLine2: String,
   addressLine3: Option[String] = None,
   townOrCity: String,
   postCode: String,

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
@@ -26,7 +26,7 @@ trait RegistrationTestData {
 
   protected val pptBusinessAddress: Address =
     Address(addressLine1 = "1 Some Street",
-            addressLine2 = Some("Some Place"),
+            addressLine2 = "Some Place",
             addressLine3 = Some("Some Area"),
             townOrCity = "Leeds",
             postCode = "LS1 1AA"
@@ -34,7 +34,7 @@ trait RegistrationTestData {
 
   protected val pptPrimaryContactAddress: Address =
     Address(addressLine1 = "2 Some Other Street",
-            addressLine2 = Some("Some Other Place"),
+            addressLine2 = "Some Other Place",
             addressLine3 = Some("Some Other Area"),
             townOrCity = "Bradford",
             postCode = "BD1 1AA"

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
@@ -29,12 +29,16 @@ class AddressDetailsSpec
 
   "AddressDetails" should {
     "map from PPT Address" when {
-      "only 'addressLine1', 'townOrCity' and 'PostCode' are available" in {
+      "only 'addressLine1', 'addressLine2', 'townOrCity' and 'PostCode' are available" in {
         val pptAddress =
-          PPTAddress(addressLine1 = "addressLine1", townOrCity = "Town", postCode = "PostCode")
+          PPTAddress(addressLine1 = "addressLine1",
+                     addressLine2 = "addressLine2",
+                     townOrCity = "Town",
+                     postCode = "PostCode"
+          )
         val addressDetails = AddressDetails(Some(pptAddress))
         addressDetails.addressLine1 mustBe pptAddress.addressLine1
-        addressDetails.addressLine2 mustBe ""
+        addressDetails.addressLine2 mustBe pptAddress.addressLine2
         addressDetails.addressLine3 mustBe None
         addressDetails.addressLine4 mustBe Some(pptAddress.townOrCity)
       }
@@ -42,7 +46,7 @@ class AddressDetailsSpec
       "all  PPT address fields are available" in {
         val addressDetails = AddressDetails(Some(pptBusinessAddress))
         addressDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-        addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2.get
+        addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
         addressDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
         addressDetails.addressLine4 mustBe Some(pptBusinessAddress.townOrCity)
       }

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.base.data.{
   SubscriptionTestData
 }
 import uk.gov.hmrc.plasticpackagingtaxregistration.builders.RegistrationBuilder
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.Address
 
 class BusinessCorrespondenceDetailsSpec
     extends AnyWordSpec with Matchers with SubscriptionTestData with RegistrationTestData
@@ -42,7 +41,7 @@ class BusinessCorrespondenceDetailsSpec
           BusinessCorrespondenceDetails(registrationUsingBusinessAddress)
 
         businessCorrespondenceDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-        businessCorrespondenceDetails.addressLine2 mustBe pptBusinessAddress.addressLine2.get
+        businessCorrespondenceDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
         businessCorrespondenceDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
         businessCorrespondenceDetails.addressLine4 mustBe Some(pptBusinessAddress.townOrCity)
         businessCorrespondenceDetails.postalCode mustBe Some(pptBusinessAddress.postCode)
@@ -62,41 +61,13 @@ class BusinessCorrespondenceDetailsSpec
           BusinessCorrespondenceDetails(registrationWithDifferentPrimaryContractAddress)
 
         businessCorrespondenceDetails.addressLine1 mustBe pptPrimaryContactAddress.addressLine1
-        businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2.get
+        businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2
         businessCorrespondenceDetails.addressLine3 mustBe pptPrimaryContactAddress.addressLine3
         businessCorrespondenceDetails.addressLine4 mustBe Some(pptPrimaryContactAddress.townOrCity)
         businessCorrespondenceDetails.postalCode mustBe Some(pptPrimaryContactAddress.postCode)
         businessCorrespondenceDetails.countryCode mustBe "GB"
       }
 
-      "primary contact supplied with discrete primary contact address with no address line 2 " in {
-        val registrationWithDifferentPrimaryContractAddressWithNoAddressLine2 =
-          aRegistration(
-            withPrimaryContactDetails(
-              pptPrimaryContactDetails.copy(address =
-                Some(
-                  Address(addressLine1 = "2 Some Other Street",
-                          addressLine3 = Some("Some Other Area"),
-                          townOrCity = "Bradford",
-                          postCode = "BD1 1AA"
-                  )
-                )
-              )
-            )
-          )
-
-        val businessCorrespondenceDetails =
-          BusinessCorrespondenceDetails(
-            registrationWithDifferentPrimaryContractAddressWithNoAddressLine2
-          )
-
-        businessCorrespondenceDetails.addressLine1 mustBe pptPrimaryContactAddress.addressLine1
-        businessCorrespondenceDetails.addressLine2 mustBe " "
-        businessCorrespondenceDetails.addressLine3 mustBe pptPrimaryContactAddress.addressLine3
-        businessCorrespondenceDetails.addressLine4 mustBe Some(pptPrimaryContactAddress.townOrCity)
-        businessCorrespondenceDetails.postalCode mustBe Some(pptPrimaryContactAddress.postCode)
-        businessCorrespondenceDetails.countryCode mustBe "GB"
-      }
     }
 
     "throw IllegalStateException" when {

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetailsSpec.scala
@@ -35,7 +35,7 @@ class PrincipalPlaceOfBusinessDetailsSpec
     "build" in {
       val principalPlaceOfBusinessDetails = PrincipalPlaceOfBusinessDetails(registration)
       principalPlaceOfBusinessDetails.addressDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-      principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2.get
+      principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
       principalPlaceOfBusinessDetails.addressDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
       principalPlaceOfBusinessDetails.addressDetails.addressLine4 mustBe Some(
         pptBusinessAddress.townOrCity

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
@@ -16,6 +16,10 @@
 
 package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
 
+import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime.now
+import java.time.format.DateTimeFormatter
+
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.plasticpackagingtaxregistration.base.data.{
@@ -23,10 +27,6 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.base.data.{
   SubscriptionTestData
 }
 import uk.gov.hmrc.plasticpackagingtaxregistration.builders.RegistrationBuilder
-
-import java.time.ZoneOffset.UTC
-import java.time.ZonedDateTime.now
-import java.time.format.DateTimeFormatter
 
 class SubscriptionSpec
     extends AnyWordSpec with Matchers with SubscriptionTestData with RegistrationTestData
@@ -121,7 +121,7 @@ class SubscriptionSpec
 
   private def mustHaveValidPrincipalPlaceOfBusinessDetails(subscription: Subscription) = {
     subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-    subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2.get
+    subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
     subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
     subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine4 mustBe Some(
       pptBusinessAddress.townOrCity
@@ -138,7 +138,7 @@ class SubscriptionSpec
 
   private def mustHaveValidBusinessCorrespondenceDetails(subscription: Subscription) = {
     subscription.businessCorrespondenceDetails.addressLine1 mustBe pptPrimaryContactAddress.addressLine1
-    subscription.businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2.get
+    subscription.businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2
     subscription.businessCorrespondenceDetails.addressLine3 mustBe pptPrimaryContactAddress.addressLine3
     subscription.businessCorrespondenceDetails.addressLine4 mustBe Some(
       pptPrimaryContactAddress.townOrCity

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationControllerSpec.scala
@@ -169,6 +169,7 @@ class RegistrationControllerSpec
                                 phoneNumber = Some("1234567890"),
                                 address = Some(
                                   Address(addressLine1 = "addressLine1",
+                                          addressLine2 = "addressLine2",
                                           townOrCity = "Town",
                                           postCode = "PostCode"
                                   )
@@ -183,6 +184,8 @@ class RegistrationControllerSpec
                                                                    Some(
                                                                      Address(addressLine1 =
                                                                                "addressLine1",
+                                                                             addressLine2 =
+                                                                               "addressLine2",
                                                                              townOrCity = "Town",
                                                                              postCode = "PostCode"
                                                                      )
@@ -201,6 +204,7 @@ class RegistrationControllerSpec
                                 phoneNumber = Some("1234567890"),
                                 address = Some(
                                   Address(addressLine1 = "addressLine1",
+                                          addressLine2 = "addressLine2",
                                           townOrCity = "Town",
                                           postCode = "PostCode"
                                   )

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/repositories/RegistrationRepositorySpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/repositories/RegistrationRepositorySpec.scala
@@ -70,11 +70,14 @@ class RegistrationRepositorySpec
 
         val registration = aRegistration(
           withOrganisationDetails(
-            OrganisationDetails(
-              organisationType = Some(OrgType.UK_COMPANY),
-              businessRegisteredAddress = Some(
-                Address(addressLine1 = "addressLine1", townOrCity = "Town", postCode = "PostCode")
-              )
+            OrganisationDetails(organisationType = Some(OrgType.UK_COMPANY),
+                                businessRegisteredAddress = Some(
+                                  Address(addressLine1 = "addressLine1",
+                                          addressLine2 = "addressLine2",
+                                          townOrCity = "Town",
+                                          postCode = "PostCode"
+                                  )
+                                )
             )
           )
         )
@@ -149,6 +152,8 @@ class RegistrationRepositorySpec
                                                                address = Some(
                                                                  Address(addressLine1 =
                                                                            "addressLine1",
+                                                                         addressLine2 =
+                                                                           "addressLine2",
                                                                          townOrCity = "Town",
                                                                          postCode = "PostCode"
                                                                  )
@@ -156,16 +161,19 @@ class RegistrationRepositorySpec
                                          )
                                        ),
                                        withOrganisationDetails(
-                                         OrganisationDetails(organisationType =
-                                                               Some(OrgType.UK_COMPANY),
-                                                             businessRegisteredAddress =
-                                                               Some(
-                                                                 Address(addressLine1 =
-                                                                           "addressLine1",
-                                                                         townOrCity = "Town",
-                                                                         postCode = "PostCode"
-                                                                 )
-                                                               )
+                                         OrganisationDetails(
+                                           organisationType =
+                                             Some(OrgType.UK_COMPANY),
+                                           businessRegisteredAddress =
+                                             Some(
+                                               Address(addressLine1 =
+                                                         "addressLine1",
+                                                       addressLine2 =
+                                                         "addressLine2",
+                                                       townOrCity = "Town",
+                                                       postCode = "PostCode"
+                                               )
+                                             )
                                          )
                                        )
       )


### PR DESCRIPTION
Update PrimaryContactDetails Address model to make line 2 non-optional
- remove fix replacing empty line 2 with a space

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
