### PR TITLE
PPTP-1353 - add group identifier to AuthorizedRequest

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationController.scala
@@ -50,7 +50,7 @@ class RegistrationController @Inject() (
       implicit request =>
         logPayload("Create Registration Request Received", request.body)
         registrationRepository
-          .create(request.body.toRegistration(request.registrationId))
+          .create(request.body.toRegistration(request.userId))
           .map(logPayload("Create Registration Response", _))
           .map(registration => Created(registration))
     }
@@ -62,7 +62,7 @@ class RegistrationController @Inject() (
         registrationRepository.findByRegistrationId(id).flatMap {
           case Some(_) =>
             registrationRepository
-              .update(request.body.toRegistration(request.registrationId))
+              .update(request.body.toRegistration(request.userId))
               .map(logPayload("Update Registration Response", _))
               .map {
                 case Some(registration) => Ok(registration)

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
@@ -71,7 +71,7 @@ class SubscriptionController @Inject() (
   def submit(safeId: String): Action[RegistrationRequest] =
     authenticator.authorisedAction(authenticator.parsingJson[RegistrationRequest]) {
       implicit request =>
-        val pptRegistration = request.body.toRegistration(request.registrationId)
+        val pptRegistration = request.body.toRegistration(request.userId)
         val pptSubscription = Subscription(pptRegistration)
         logPayload(s"PPT Subscription Create request for safeId $safeId ", pptSubscription)
 
@@ -88,7 +88,7 @@ class SubscriptionController @Inject() (
               for {
                 enrolmentResponse <- enrolUser(pptReferenceNumber, safeId, formBundleNumber)
                 nrsResponse       <- notifyNRS(request, pptRegistration, subscriptionResponse)
-                _                 <- deleteRegistration(request.registrationId)
+                _                 <- deleteRegistration(request.userId)
               } yield Ok(
                 SubscriptionCreateWithEnrolmentAndNrsStatusesResponse(
                   pptReference = pptReferenceNumber,

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/actions/AuthenticatorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/actions/AuthenticatorSpec.scala
@@ -45,7 +45,7 @@ class AuthenticatorSpec
       "if user is not authorised" in {
         withUnauthorizedUser(InsufficientConfidenceLevel("User not authorised"))
 
-        val result = await(authenticator.authorisedWithInternalId(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
 
         result.left.value.statusCode mustBe UNAUTHORIZED
       }
@@ -55,19 +55,30 @@ class AuthenticatorSpec
       "when returning the InternalId results in an exception" in {
         withUnauthorizedUser(new Exception("Something went wrong"))
 
-        val result = await(authenticator.authorisedWithInternalId(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
 
         result.left.value.statusCode mustBe INTERNAL_SERVER_ERROR
       }
     }
 
+    "return 401 unauthorised " when {
+      "user group not available" in {
+        withAuthorizedUser(newUser(), userGroup = None)
+
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
+
+        result.left.value.statusCode mustBe UNAUTHORIZED
+      }
+    }
+
     "return 200" when {
-      "internalId is available" in {
+      "internalId and group identifier is available" in {
         withAuthorizedUser(newUser())
 
-        val result = await(authenticator.authorisedWithInternalId(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
 
-        result.value.registrationId mustBe "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"
+        result.value.userId mustBe userInternalId
+        result.value.groupId mustBe userGroupIdentifier
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
@@ -32,16 +32,28 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.services.nrs.NonRepudiationSe
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
+
 trait AuthTestSupport extends MockitoSugar {
 
   lazy val mockAuthConnector: AuthConnector = mock[AuthConnector]
   lazy val mockLogger: Logger               = mock[Logger]
 
-  val userInternalId = "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"
+  val userInternalId      = "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"
+  val userGroupIdentifier = "testGroupId-419b91bc-8f97-4b5e-85ef-d58d4cfd4bb8"
 
-  def withAuthorizedUser(user: SignedInUser = newUser()): Unit =
-    when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(internalId))(any(), any()))
-      .thenReturn(Future.successful(user.internalId))
+  def withAuthorizedUser(
+    user: SignedInUser = newUser(),
+    userGroup: Option[String] = Some(userGroupIdentifier)
+  ): Unit =
+    when(
+      mockAuthConnector.authorise(any(), ArgumentMatchers.eq(internalId and groupIdentifier))(any(),
+                                                                                              any()
+      )
+    )
+      .thenReturn(Future.successful(new ~(user.internalId, userGroup)))
 
   def withUnauthorizedUser(error: Throwable): Unit =
     when(mockAuthConnector.authorise(any(), any())(any(), any())).thenReturn(Future.failed(error))


### PR DESCRIPTION
Add group identifier to internalId so that it can be used for tax-enrolment request and group enrolled checks

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
