### PR TITLE
PPTP-1353 - extract credentials from auth

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationController.scala
@@ -50,7 +50,7 @@ class RegistrationController @Inject() (
       implicit request =>
         logPayload("Create Registration Request Received", request.body)
         registrationRepository
-          .create(request.body.toRegistration(request.userId))
+          .create(request.body.toRegistration(request.registrationId))
           .map(logPayload("Create Registration Response", _))
           .map(registration => Created(registration))
     }
@@ -62,7 +62,7 @@ class RegistrationController @Inject() (
         registrationRepository.findByRegistrationId(id).flatMap {
           case Some(_) =>
             registrationRepository
-              .update(request.body.toRegistration(request.userId))
+              .update(request.body.toRegistration(request.registrationId))
               .map(logPayload("Update Registration Response", _))
               .map {
                 case Some(registration) => Ok(registration)

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
@@ -71,7 +71,7 @@ class SubscriptionController @Inject() (
   def submit(safeId: String): Action[RegistrationRequest] =
     authenticator.authorisedAction(authenticator.parsingJson[RegistrationRequest]) {
       implicit request =>
-        val pptRegistration = request.body.toRegistration(request.userId)
+        val pptRegistration = request.body.toRegistration(request.registrationId)
         val pptSubscription = Subscription(pptRegistration)
         logPayload(s"PPT Subscription Create request for safeId $safeId ", pptSubscription)
 
@@ -88,7 +88,7 @@ class SubscriptionController @Inject() (
               for {
                 enrolmentResponse <- enrolUser(pptReferenceNumber, safeId, formBundleNumber)
                 nrsResponse       <- notifyNRS(request, pptRegistration, subscriptionResponse)
-                _                 <- deleteRegistration(request.userId)
+                _                 <- deleteRegistration(request.registrationId)
               } yield Ok(
                 SubscriptionCreateWithEnrolmentAndNrsStatusesResponse(
                   pptReference = pptReferenceNumber,

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/actions/AuthenticatorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/actions/AuthenticatorSpec.scala
@@ -69,15 +69,23 @@ class AuthenticatorSpec
 
         result.left.value.statusCode mustBe UNAUTHORIZED
       }
+      "user credentials not available" in {
+        withAuthorizedUser(newUser(), userCredentials = None)
+
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
+
+        result.left.value.statusCode mustBe UNAUTHORIZED
+      }
     }
 
     "return 200" when {
-      "internalId and group identifier is available" in {
+      "internalId, credentials and group identifier is available" in {
         withAuthorizedUser(newUser())
 
         val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
 
-        result.value.userId mustBe userInternalId
+        result.value.registrationId mustBe userInternalId
+        result.value.userId mustBe userCredentialsId
         result.value.groupId mustBe userGroupIdentifier
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
@@ -24,17 +24,13 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.Logger
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.internalId
-import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name, Retrieval}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{internalId, _}
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name, Retrieval, _}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.SignedInUser
 import uk.gov.hmrc.plasticpackagingtaxregistration.services.nrs.NonRepudiationService.NonRepudiationIdentityRetrievals
 
 import scala.concurrent.{ExecutionContext, Future}
-
-import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.retrieve._
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 
 trait AuthTestSupport extends MockitoSugar {
 
@@ -43,17 +39,20 @@ trait AuthTestSupport extends MockitoSugar {
 
   val userInternalId      = "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"
   val userGroupIdentifier = "testGroupId-419b91bc-8f97-4b5e-85ef-d58d4cfd4bb8"
+  val userCredentialsId   = "12342370495723"
 
   def withAuthorizedUser(
     user: SignedInUser = newUser(),
-    userGroup: Option[String] = Some(userGroupIdentifier)
+    userGroup: Option[String] = Some(userGroupIdentifier),
+    userCredentials: Option[Credentials] = Some(Credentials(userCredentialsId, "GovernmentGateway"))
   ): Unit =
     when(
-      mockAuthConnector.authorise(any(), ArgumentMatchers.eq(internalId and groupIdentifier))(any(),
-                                                                                              any()
-      )
+      mockAuthConnector.authorise(
+        any(),
+        ArgumentMatchers.eq(internalId and credentials and groupIdentifier)
+      )(any(), any())
     )
-      .thenReturn(Future.successful(new ~(user.internalId, userGroup)))
+      .thenReturn(Future.successful(new ~(new ~(user.internalId, userCredentials), userGroup)))
 
   def withUnauthorizedUser(error: Throwable): Unit =
     when(mockAuthConnector.authorise(any(), any())(any(), any())).thenReturn(Future.failed(error))


### PR DESCRIPTION
- credentials.providerId is to be user as `userId` in API tax enrolment calls
- revert userId field in `AuthorizedRequest` back to previous name `registrationId`

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
