### PR TITLE
PPTP-1243 - support for optional address line 2

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
@@ -32,14 +32,14 @@ case class AddressDetails(
 object AddressDetails {
   implicit val format: OFormat[AddressDetails] = Json.format[AddressDetails]
 
-  def apply(address: Option[PPTAddress]): AddressDetails =
-    address match {
-      case Some(addressDetails) =>
-        AddressDetails(addressLine1 = addressDetails.addressLine1,
-                       addressLine2 = addressDetails.addressLine2,
-                       addressLine3 = addressDetails.addressLine3,
-                       addressLine4 = Some(addressDetails.townOrCity),
-                       postalCode = Some(addressDetails.postCode),
+  def apply(maybeAddress: Option[PPTAddress]): AddressDetails =
+    maybeAddress match {
+      case Some(address) =>
+        AddressDetails(addressLine1 = address.eisAddressLines._1,
+                       addressLine2 = address.eisAddressLines._2,
+                       addressLine3 = address.eisAddressLines._3,
+                       addressLine4 = address.eisAddressLines._4,
+                       postalCode = Some(address.postCode),
                        countryCode = "GB"
         )
       case None => throw InternalError(s"The legal entity registered address is required.")

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
 
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.Registration
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.{Address, Registration}
 
 case class BusinessCorrespondenceDetails(
   addressLine1: String,
@@ -34,7 +34,7 @@ object BusinessCorrespondenceDetails {
     Json.format[BusinessCorrespondenceDetails]
 
   def apply(registration: Registration): BusinessCorrespondenceDetails = {
-    val businessCorrespondenceAddress =
+    val address =
       if (registration.primaryContactDetails.useRegisteredAddress.getOrElse(false))
         registration.organisationDetails.businessRegisteredAddress.getOrElse(
           throw new IllegalStateException((s"The legal entity registered address is required."))
@@ -44,13 +44,16 @@ object BusinessCorrespondenceDetails {
           throw new IllegalStateException(s"The primary contact details address is required.")
         )
 
-    BusinessCorrespondenceDetails(addressLine1 = businessCorrespondenceAddress.addressLine1,
-                                  addressLine2 = businessCorrespondenceAddress.addressLine2,
-                                  addressLine3 = businessCorrespondenceAddress.addressLine3,
-                                  addressLine4 = Some(businessCorrespondenceAddress.townOrCity),
-                                  postalCode = Some(businessCorrespondenceAddress.postCode),
-                                  countryCode = "GB"
-    )
+    BusinessCorrespondenceDetails(address)
   }
+
+  def apply(address: Address): BusinessCorrespondenceDetails =
+    new BusinessCorrespondenceDetails(addressLine1 = address.eisAddressLines._1,
+                                      addressLine2 = address.eisAddressLines._2,
+                                      addressLine3 = address.eisAddressLines._3,
+                                      addressLine4 = address.eisAddressLines._4,
+                                      postalCode = Some(address.postCode),
+                                      countryCode = "GB"
+    )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PrimaryContactDetails.scala
@@ -20,12 +20,19 @@ import play.api.libs.json.{Json, OFormat}
 
 case class Address(
   addressLine1: String,
-  addressLine2: String,
+  addressLine2: Option[String] = None,
   addressLine3: Option[String] = None,
   townOrCity: String,
   postCode: String,
   country: Option[String] = Some("GB")
-)
+) {
+
+  val eisAddressLines: (String, String, Option[String], Option[String]) = {
+    val list = Seq(Some(addressLine1), addressLine2, addressLine3, Some(townOrCity)).flatten
+    (list.head, list(1), list.lift(2), list.lift(3))
+  }
+
+}
 
 object Address {
   implicit val format: OFormat[Address] = Json.format[Address]

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
@@ -26,7 +26,7 @@ trait RegistrationTestData {
 
   protected val pptBusinessAddress: Address =
     Address(addressLine1 = "1 Some Street",
-            addressLine2 = "Some Place",
+            addressLine2 = Some("Some Place"),
             addressLine3 = Some("Some Area"),
             townOrCity = "Leeds",
             postCode = "LS1 1AA"
@@ -34,7 +34,7 @@ trait RegistrationTestData {
 
   protected val pptPrimaryContactAddress: Address =
     Address(addressLine1 = "2 Some Other Street",
-            addressLine2 = "Some Other Place",
+            addressLine2 = Some("Some Other Place"),
             addressLine3 = Some("Some Other Area"),
             townOrCity = "Bradford",
             postCode = "BD1 1AA"

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
@@ -29,26 +29,46 @@ class AddressDetailsSpec
 
   "AddressDetails" should {
     "map from PPT Address" when {
+      "only 'addressLine1', 'townOrCity' and 'PostCode' are available" in {
+        val pptAddress =
+          PPTAddress(addressLine1 = "addressLine1", townOrCity = "Town", postCode = "PostCode")
+        val addressDetails = AddressDetails(Some(pptAddress))
+        addressDetails.addressLine1 mustBe "addressLine1"
+        addressDetails.addressLine2 mustBe "Town"
+        addressDetails.addressLine3 mustBe None
+        addressDetails.addressLine4 mustBe None
+        addressDetails.postalCode mustBe Some("PostCode")
+      }
+
       "only 'addressLine1', 'addressLine2', 'townOrCity' and 'PostCode' are available" in {
         val pptAddress =
           PPTAddress(addressLine1 = "addressLine1",
-                     addressLine2 = "addressLine2",
+                     addressLine2 = Some("addressLine2"),
                      townOrCity = "Town",
                      postCode = "PostCode"
           )
         val addressDetails = AddressDetails(Some(pptAddress))
-        addressDetails.addressLine1 mustBe pptAddress.addressLine1
-        addressDetails.addressLine2 mustBe pptAddress.addressLine2
-        addressDetails.addressLine3 mustBe None
-        addressDetails.addressLine4 mustBe Some(pptAddress.townOrCity)
+        addressDetails.addressLine1 mustBe "addressLine1"
+        addressDetails.addressLine2 mustBe "addressLine2"
+        addressDetails.addressLine3 mustBe Some("Town")
+        addressDetails.addressLine4 mustBe None
+        addressDetails.postalCode mustBe Some("PostCode")
       }
 
       "all  PPT address fields are available" in {
-        val addressDetails = AddressDetails(Some(pptBusinessAddress))
-        addressDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-        addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
-        addressDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
-        addressDetails.addressLine4 mustBe Some(pptBusinessAddress.townOrCity)
+        val pptAddress =
+          PPTAddress(addressLine1 = "addressLine1",
+                     addressLine2 = Some("addressLine2"),
+                     addressLine3 = Some("addressLine3"),
+                     townOrCity = "Town",
+                     postCode = "PostCode"
+          )
+        val addressDetails = AddressDetails(Some(pptAddress))
+        addressDetails.addressLine1 mustBe "addressLine1"
+        addressDetails.addressLine2 mustBe "addressLine2"
+        addressDetails.addressLine3 mustBe Some("addressLine3")
+        addressDetails.addressLine4 mustBe Some("Town")
+        addressDetails.postalCode mustBe Some("PostCode")
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.base.data.{
   SubscriptionTestData
 }
 import uk.gov.hmrc.plasticpackagingtaxregistration.builders.RegistrationBuilder
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.Address
 
 class BusinessCorrespondenceDetailsSpec
     extends AnyWordSpec with Matchers with SubscriptionTestData with RegistrationTestData
@@ -41,7 +42,9 @@ class BusinessCorrespondenceDetailsSpec
           BusinessCorrespondenceDetails(registrationUsingBusinessAddress)
 
         businessCorrespondenceDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-        businessCorrespondenceDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
+        businessCorrespondenceDetails.addressLine2 mustBe pptBusinessAddress.addressLine2.getOrElse(
+          ""
+        )
         businessCorrespondenceDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
         businessCorrespondenceDetails.addressLine4 mustBe Some(pptBusinessAddress.townOrCity)
         businessCorrespondenceDetails.postalCode mustBe Some(pptBusinessAddress.postCode)
@@ -61,12 +64,65 @@ class BusinessCorrespondenceDetailsSpec
           BusinessCorrespondenceDetails(registrationWithDifferentPrimaryContractAddress)
 
         businessCorrespondenceDetails.addressLine1 mustBe pptPrimaryContactAddress.addressLine1
-        businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2
+        businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2.getOrElse(
+          ""
+        )
         businessCorrespondenceDetails.addressLine3 mustBe pptPrimaryContactAddress.addressLine3
         businessCorrespondenceDetails.addressLine4 mustBe Some(pptPrimaryContactAddress.townOrCity)
         businessCorrespondenceDetails.postalCode mustBe Some(pptPrimaryContactAddress.postCode)
         businessCorrespondenceDetails.countryCode mustBe "GB"
       }
+
+    }
+
+    "map address with one line" in {
+
+      val businessCorrespondenceDetails = BusinessCorrespondenceDetails(
+        Address(addressLine1 = "line1", townOrCity = "town", postCode = "postcode")
+      )
+      businessCorrespondenceDetails.addressLine1 mustBe "line1"
+      businessCorrespondenceDetails.addressLine2 mustBe "town"
+      businessCorrespondenceDetails.addressLine3 mustBe None
+      businessCorrespondenceDetails.addressLine4 mustBe None
+      businessCorrespondenceDetails.postalCode mustBe Some("postcode")
+      businessCorrespondenceDetails.countryCode mustBe "GB" // default
+
+    }
+
+    "map address with two lines" in {
+
+      val businessCorrespondenceDetails = BusinessCorrespondenceDetails(
+        Address(addressLine1 = "line1",
+                addressLine2 = Some("line2"),
+                townOrCity = "town",
+                postCode = "postcode"
+        )
+      )
+      businessCorrespondenceDetails.addressLine1 mustBe "line1"
+      businessCorrespondenceDetails.addressLine2 mustBe "line2"
+      businessCorrespondenceDetails.addressLine3 mustBe Some("town")
+      businessCorrespondenceDetails.addressLine4 mustBe None
+      businessCorrespondenceDetails.postalCode mustBe Some("postcode")
+      businessCorrespondenceDetails.countryCode mustBe "GB" // default
+
+    }
+
+    "map address with three lines" in {
+
+      val businessCorrespondenceDetails = BusinessCorrespondenceDetails(
+        Address(addressLine1 = "line1",
+                addressLine2 = Some("line2"),
+                addressLine3 = Some("line3"),
+                townOrCity = "town",
+                postCode = "postcode"
+        )
+      )
+      businessCorrespondenceDetails.addressLine1 mustBe "line1"
+      businessCorrespondenceDetails.addressLine2 mustBe "line2"
+      businessCorrespondenceDetails.addressLine3 mustBe Some("line3")
+      businessCorrespondenceDetails.addressLine4 mustBe Some("town")
+      businessCorrespondenceDetails.postalCode mustBe Some("postcode")
+      businessCorrespondenceDetails.countryCode mustBe "GB" // default
 
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetailsSpec.scala
@@ -35,7 +35,9 @@ class PrincipalPlaceOfBusinessDetailsSpec
     "build" in {
       val principalPlaceOfBusinessDetails = PrincipalPlaceOfBusinessDetails(registration)
       principalPlaceOfBusinessDetails.addressDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-      principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
+      principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2.getOrElse(
+        ""
+      )
       principalPlaceOfBusinessDetails.addressDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
       principalPlaceOfBusinessDetails.addressDetails.addressLine4 mustBe Some(
         pptBusinessAddress.townOrCity

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
@@ -121,7 +121,9 @@ class SubscriptionSpec
 
   private def mustHaveValidPrincipalPlaceOfBusinessDetails(subscription: Subscription) = {
     subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine1 mustBe pptBusinessAddress.addressLine1
-    subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2
+    subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine2 mustBe pptBusinessAddress.addressLine2.getOrElse(
+      ""
+    )
     subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine3 mustBe pptBusinessAddress.addressLine3
     subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine4 mustBe Some(
       pptBusinessAddress.townOrCity
@@ -138,7 +140,9 @@ class SubscriptionSpec
 
   private def mustHaveValidBusinessCorrespondenceDetails(subscription: Subscription) = {
     subscription.businessCorrespondenceDetails.addressLine1 mustBe pptPrimaryContactAddress.addressLine1
-    subscription.businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2
+    subscription.businessCorrespondenceDetails.addressLine2 mustBe pptPrimaryContactAddress.addressLine2.getOrElse(
+      ""
+    )
     subscription.businessCorrespondenceDetails.addressLine3 mustBe pptPrimaryContactAddress.addressLine3
     subscription.businessCorrespondenceDetails.addressLine4 mustBe Some(
       pptPrimaryContactAddress.townOrCity

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationControllerSpec.scala
@@ -169,7 +169,7 @@ class RegistrationControllerSpec
                                 phoneNumber = Some("1234567890"),
                                 address = Some(
                                   Address(addressLine1 = "addressLine1",
-                                          addressLine2 = "addressLine2",
+                                          addressLine2 = Some("addressLine2"),
                                           townOrCity = "Town",
                                           postCode = "PostCode"
                                   )
@@ -185,7 +185,7 @@ class RegistrationControllerSpec
                                                                      Address(addressLine1 =
                                                                                "addressLine1",
                                                                              addressLine2 =
-                                                                               "addressLine2",
+                                                                               Some("addressLine2"),
                                                                              townOrCity = "Town",
                                                                              postCode = "PostCode"
                                                                      )
@@ -204,7 +204,7 @@ class RegistrationControllerSpec
                                 phoneNumber = Some("1234567890"),
                                 address = Some(
                                   Address(addressLine1 = "addressLine1",
-                                          addressLine2 = "addressLine2",
+                                          addressLine2 = Some("addressLine2"),
                                           townOrCity = "Town",
                                           postCode = "PostCode"
                                   )

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/repositories/RegistrationRepositorySpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/repositories/RegistrationRepositorySpec.scala
@@ -73,7 +73,7 @@ class RegistrationRepositorySpec
             OrganisationDetails(organisationType = Some(OrgType.UK_COMPANY),
                                 businessRegisteredAddress = Some(
                                   Address(addressLine1 = "addressLine1",
-                                          addressLine2 = "addressLine2",
+                                          addressLine2 = Some("addressLine2"),
                                           townOrCity = "Town",
                                           postCode = "PostCode"
                                   )
@@ -153,7 +153,7 @@ class RegistrationRepositorySpec
                                                                  Address(addressLine1 =
                                                                            "addressLine1",
                                                                          addressLine2 =
-                                                                           "addressLine2",
+                                                                           Some("addressLine2"),
                                                                          townOrCity = "Town",
                                                                          postCode = "PostCode"
                                                                  )
@@ -169,7 +169,7 @@ class RegistrationRepositorySpec
                                                Address(addressLine1 =
                                                          "addressLine1",
                                                        addressLine2 =
-                                                         "addressLine2",
+                                                         Some("addressLine2"),
                                                        townOrCity = "Town",
                                                        postCode = "PostCode"
                                                )


### PR DESCRIPTION
NOTE:  With this implementation the "town" value that we capture will not always be sent to EIS as "addressLine4" - it might be addressLine2, addressLine3 or addressLine4 depending on the number of lines captured.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
