### PR TITLE
BAU - refactor Address models to simplify and remove redundant code

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
 
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.auth.core.InternalError
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.{Address => PPTAddress}
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.PPTAddress
 
 case class AddressDetails(
   addressLine1: String,
@@ -32,17 +31,13 @@ case class AddressDetails(
 object AddressDetails {
   implicit val format: OFormat[AddressDetails] = Json.format[AddressDetails]
 
-  def apply(maybeAddress: Option[PPTAddress]): AddressDetails =
-    maybeAddress match {
-      case Some(address) =>
-        AddressDetails(addressLine1 = address.eisAddressLines._1,
-                       addressLine2 = address.eisAddressLines._2,
-                       addressLine3 = address.eisAddressLines._3,
-                       addressLine4 = address.eisAddressLines._4,
-                       postalCode = address.postCode,
-                       countryCode = address.countryCode
-        )
-      case None => throw InternalError(s"The legal entity registered address is required.")
-    }
+  def apply(address: PPTAddress): AddressDetails =
+    AddressDetails(addressLine1 = address.eisAddressLines._1,
+                   addressLine2 = address.eisAddressLines._2,
+                   addressLine3 = address.eisAddressLines._3,
+                   addressLine4 = address.eisAddressLines._4,
+                   postalCode = address.postCode,
+                   countryCode = address.countryCode
+    )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
 
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.{Address, Registration}
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.{PPTAddress, Registration}
 
 case class BusinessCorrespondenceDetails(
   addressLine1: String,
@@ -47,7 +47,7 @@ object BusinessCorrespondenceDetails {
     BusinessCorrespondenceDetails(address)
   }
 
-  def apply(address: Address): BusinessCorrespondenceDetails =
+  def apply(address: PPTAddress): BusinessCorrespondenceDetails =
     new BusinessCorrespondenceDetails(addressLine1 = address.eisAddressLines._1,
                                       addressLine2 = address.eisAddressLines._2,
                                       addressLine3 = address.eisAddressLines._3,

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
@@ -16,6 +16,9 @@
 
 package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
 
+import java.time.format.DateTimeFormatter
+import java.time.{ZoneOffset, ZonedDateTime}
+
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.CustomerType.{
   Individual,
@@ -30,8 +33,6 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.models.{
   OrganisationDetails => PPTOrganisationDetails
 }
 
-import java.time.format.DateTimeFormatter
-import java.time.{ZoneOffset, ZonedDateTime}
 import scala.language.implicitConversions
 
 case class LegalEntityDetails(

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetails.scala
@@ -29,7 +29,7 @@ object PrincipalPlaceOfBusinessDetails {
 
   def apply(registration: Registration): PrincipalPlaceOfBusinessDetails =
     PrincipalPlaceOfBusinessDetails(
-      addressDetails = AddressDetails(registration.organisationDetails.businessRegisteredAddress),
+      addressDetails = AddressDetails(registration.organisationDetails.registeredBusinessAddress),
       contactDetails = ContactDetails(registration.primaryContactDetails.email.getOrElse(""),
                                       telephone =
                                         registration.primaryContactDetails.phoneNumber.getOrElse("")

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/group/GroupPartnershipSubscription.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/group/GroupPartnershipSubscription.scala
@@ -18,19 +18,15 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscr
 
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{
+  AddressDetails,
   ContactDetails,
   IndividualDetails,
-  AddressDetails => SubscriptionAddressDetails,
   OrganisationDetails => SubscriptionOrganisationDetails
 }
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.group.{
-  GroupMember,
-  AddressDetails => RegistrationAddressDetails
-}
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.group.GroupMember
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.{
   PrimaryContactDetails,
   Registration,
-  Address => RegistrationPrimaryContactAddress,
   OrganisationDetails => RegistrationOrganisationDetails
 }
 
@@ -89,7 +85,7 @@ object GroupPartnershipSubscription {
                             organisationDetails = toGroupOrganisationDetails(organisationDetails),
                             individualDetails = toIndividualDetails(primaryContactDetails),
                             addressDetails =
-                              toAddressDetails(organisationDetails.businessRegisteredAddress),
+                              AddressDetails(organisationDetails.registeredBusinessAddress),
                             contactDetails = ContactDetails(primaryContactDetails)
     )
 
@@ -111,23 +107,8 @@ object GroupPartnershipSubscription {
                             ),
                             individualDetails =
                               toIndividualDetails(registration.primaryContactDetails),
-                            addressDetails = toSubscriptionAddressDetails(member.addressDetails),
+                            addressDetails = AddressDetails(member.addressDetails),
                             contactDetails = ContactDetails(registration.primaryContactDetails)
-    )
-
-  private def toAddressDetails(
-    address: Option[RegistrationPrimaryContactAddress]
-  ): SubscriptionAddressDetails = SubscriptionAddressDetails(address)
-
-  private def toSubscriptionAddressDetails(
-    address: RegistrationAddressDetails
-  ): SubscriptionAddressDetails =
-    SubscriptionAddressDetails(address.addressLine1,
-                               address.addressLine2,
-                               address.addressLine3,
-                               address.addressLine4,
-                               address.postalCode,
-                               address.countryCode
     )
 
   private def toGroupOrganisationDetails(

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.models
 
 import play.api.libs.json._
+import uk.gov.hmrc.auth.core.InternalError
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatus.Status
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.OrgType.OrgType
 
@@ -38,13 +39,20 @@ object OrgType extends Enumeration {
 
 case class OrganisationDetails(
   organisationType: Option[OrgType] = None,
-  businessRegisteredAddress: Option[Address] = None,
+  businessRegisteredAddress: Option[PPTAddress] = None,
   safeNumber: Option[String] = None,
   soleTraderDetails: Option[SoleTraderIncorporationDetails] = None,
   partnershipDetails: Option[PartnershipDetails] = None,
   incorporationDetails: Option[IncorporationDetails] = None,
   subscriptionStatus: Option[Status] = None
-)
+) {
+
+  def registeredBusinessAddress: PPTAddress =
+    businessRegisteredAddress.getOrElse(
+      throw InternalError(s"The legal entity registered address is required.")
+    )
+
+}
 
 object OrganisationDetails {
   implicit val format: OFormat[OrganisationDetails] = Json.format[OrganisationDetails]

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddress.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddress.scala
@@ -14,19 +14,26 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtaxregistration.models.group
+package uk.gov.hmrc.plasticpackagingtaxregistration.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class AddressDetails(
+case class PPTAddress(
   addressLine1: String,
-  addressLine2: String,
+  addressLine2: Option[String] = None,
   addressLine3: Option[String] = None,
-  addressLine4: Option[String] = None,
-  postalCode: Option[String] = None,
-  countryCode: String
-)
+  townOrCity: String,
+  postCode: Option[String],
+  countryCode: String = "GB"
+) {
 
-object AddressDetails {
-  implicit val format: OFormat[AddressDetails] = Json.format[AddressDetails]
+  val eisAddressLines: (String, String, Option[String], Option[String]) = {
+    val list = Seq(Some(addressLine1), addressLine2, addressLine3, Some(townOrCity)).flatten
+    (list.head, list(1), list.lift(2), list.lift(3))
+  }
+
+}
+
+object PPTAddress {
+  implicit val format: OFormat[PPTAddress] = Json.format[PPTAddress]
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PrimaryContactDetails.scala
@@ -18,33 +18,13 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class Address(
-  addressLine1: String,
-  addressLine2: Option[String] = None,
-  addressLine3: Option[String] = None,
-  townOrCity: String,
-  postCode: Option[String],
-  countryCode: String = "GB"
-) {
-
-  val eisAddressLines: (String, String, Option[String], Option[String]) = {
-    val list = Seq(Some(addressLine1), addressLine2, addressLine3, Some(townOrCity)).flatten
-    (list.head, list(1), list.lift(2), list.lift(3))
-  }
-
-}
-
-object Address {
-  implicit val format: OFormat[Address] = Json.format[Address]
-}
-
 case class PrimaryContactDetails(
   name: Option[String] = None,
   jobTitle: Option[String] = None,
   email: Option[String] = None,
   phoneNumber: Option[String] = None,
   useRegisteredAddress: Option[Boolean] = None,
-  address: Option[Address] = None,
+  address: Option[PPTAddress] = None,
   journeyId: Option[String] = None
 )
 

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/group/GroupMember.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/group/GroupMember.scala
@@ -17,13 +17,14 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.models.group
 
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.PPTAddress
 
 case class GroupMember(
   id: String,
   customerIdentification1: String,
   customerIdentification2: Option[String],
   organisationDetails: Option[OrganisationDetails],
-  addressDetails: AddressDetails
+  addressDetails: PPTAddress
 )
 
 object GroupMember {

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
@@ -20,29 +20,28 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.models.PartnershipTypeEnum.{
   GENERAL_PARTNERSHIP,
   SCOTTISH_PARTNERSHIP
 }
+import uk.gov.hmrc.plasticpackagingtaxregistration.models._
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.group.{
-  AddressDetails,
   GroupMember,
   OrganisationDetails => GroupOrganisationDetails
 }
-import uk.gov.hmrc.plasticpackagingtaxregistration.models._
 
 trait RegistrationTestData {
 
-  protected val pptBusinessAddress: Address =
-    Address(addressLine1 = "1 Some Street",
-            addressLine2 = Some("Some Place"),
-            addressLine3 = Some("Some Area"),
-            townOrCity = "Leeds",
-            postCode = Some("LS1 1AA")
+  protected val pptBusinessAddress: PPTAddress =
+    PPTAddress(addressLine1 = "1 Some Street",
+               addressLine2 = Some("Some Place"),
+               addressLine3 = Some("Some Area"),
+               townOrCity = "Leeds",
+               postCode = Some("LS1 1AA")
     )
 
-  protected val pptPrimaryContactAddress: Address =
-    Address(addressLine1 = "2 Some Other Street",
-            addressLine2 = Some("Some Other Place"),
-            addressLine3 = Some("Some Other Area"),
-            townOrCity = "Bradford",
-            postCode = Some("BD1 1AA")
+  protected val pptPrimaryContactAddress: PPTAddress =
+    PPTAddress(addressLine1 = "2 Some Other Street",
+               addressLine2 = Some("Some Other Place"),
+               addressLine3 = Some("Some Other Area"),
+               townOrCity = "Bradford",
+               postCode = Some("BD1 1AA")
     )
 
   protected val incorporationRegistrationDetails: IncorporationRegistrationDetails =
@@ -138,12 +137,12 @@ trait RegistrationTestData {
     startDate = Some(Date(day = Some(6), month = Some(4), year = Some(2022)))
   )
 
-  protected val groupAddressDetails: AddressDetails = AddressDetails(addressLine1 = "Line 1",
-                                                                     addressLine2 = "Line 2",
-                                                                     addressLine3 = Some("Line 3"),
-                                                                     addressLine4 = Some("Line 4"),
-                                                                     Some("postcode"),
-                                                                     "GB"
+  protected val groupAddressDetails: PPTAddress = PPTAddress(addressLine1 = "Line 1",
+                                                             addressLine2 = Some("Line 2"),
+                                                             addressLine3 = Some("Line 3"),
+                                                             townOrCity = "Line 4",
+                                                             Some("postcode"),
+                                                             "GB"
   )
 
   protected val groupDetail = GroupDetail(membersUnderGroupControl = Some(true),

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscr
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.plasticpackagingtaxregistration.base.data.RegistrationTestData
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.{Address => PPTAddress}
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.PPTAddress
 
 class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTestData {
 
@@ -31,7 +31,7 @@ class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTest
                      townOrCity = "Town",
                      postCode = Some("PostCode")
           )
-        val addressDetails = AddressDetails(Some(pptAddress))
+        val addressDetails = AddressDetails(pptAddress)
         addressDetails.addressLine1 mustBe "addressLine1"
         addressDetails.addressLine2 mustBe "Town"
         addressDetails.addressLine3 mustBe None
@@ -46,7 +46,7 @@ class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTest
                      townOrCity = "Town",
                      postCode = Some("PostCode")
           )
-        val addressDetails = AddressDetails(Some(pptAddress))
+        val addressDetails = AddressDetails(pptAddress)
         addressDetails.addressLine1 mustBe "addressLine1"
         addressDetails.addressLine2 mustBe "addressLine2"
         addressDetails.addressLine3 mustBe Some("Town")
@@ -62,18 +62,12 @@ class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTest
                      townOrCity = "Town",
                      postCode = Some("PostCode")
           )
-        val addressDetails = AddressDetails(Some(pptAddress))
+        val addressDetails = AddressDetails(pptAddress)
         addressDetails.addressLine1 mustBe "addressLine1"
         addressDetails.addressLine2 mustBe "addressLine2"
         addressDetails.addressLine3 mustBe Some("addressLine3")
         addressDetails.addressLine4 mustBe Some("Town")
         addressDetails.postalCode mustBe Some("PostCode")
-      }
-    }
-
-    "throw exception if PPT Address is not available" in {
-      intercept[Exception] {
-        AddressDetails(None)
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.plasticpackagingtaxregistration.base.data.RegistrationTestData
 import uk.gov.hmrc.plasticpackagingtaxregistration.builders.RegistrationBuilder
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.Address
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.PPTAddress
 
 class BusinessCorrespondenceDetailsSpec
     extends AnyWordSpec with Matchers with RegistrationTestData with RegistrationBuilder {
@@ -74,7 +74,7 @@ class BusinessCorrespondenceDetailsSpec
     "map address with one line" in {
 
       val businessCorrespondenceDetails = BusinessCorrespondenceDetails(
-        Address(addressLine1 = "line1", townOrCity = "town", postCode = Some("postcode"))
+        PPTAddress(addressLine1 = "line1", townOrCity = "town", postCode = Some("postcode"))
       )
       businessCorrespondenceDetails.addressLine1 mustBe "line1"
       businessCorrespondenceDetails.addressLine2 mustBe "town"
@@ -88,10 +88,10 @@ class BusinessCorrespondenceDetailsSpec
     "map address with two lines" in {
 
       val businessCorrespondenceDetails = BusinessCorrespondenceDetails(
-        Address(addressLine1 = "line1",
-                addressLine2 = Some("line2"),
-                townOrCity = "town",
-                postCode = Some("postcode")
+        PPTAddress(addressLine1 = "line1",
+                   addressLine2 = Some("line2"),
+                   townOrCity = "town",
+                   postCode = Some("postcode")
         )
       )
       businessCorrespondenceDetails.addressLine1 mustBe "line1"
@@ -106,11 +106,11 @@ class BusinessCorrespondenceDetailsSpec
     "map address with three lines" in {
 
       val businessCorrespondenceDetails = BusinessCorrespondenceDetails(
-        Address(addressLine1 = "line1",
-                addressLine2 = Some("line2"),
-                addressLine3 = Some("line3"),
-                townOrCity = "town",
-                postCode = Some("postcode")
+        PPTAddress(addressLine1 = "line1",
+                   addressLine2 = Some("line2"),
+                   addressLine3 = Some("line3"),
+                   townOrCity = "town",
+                   postCode = Some("postcode")
         )
       )
       businessCorrespondenceDetails.addressLine1 mustBe "line1"

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/RegistrationControllerSpec.scala
@@ -168,10 +168,10 @@ class RegistrationControllerSpec
                                 email = Some("test@test.com"),
                                 phoneNumber = Some("1234567890"),
                                 address = Some(
-                                  Address(addressLine1 = "addressLine1",
-                                          addressLine2 = Some("addressLine2"),
-                                          townOrCity = "Town",
-                                          postCode = Some("PostCode")
+                                  PPTAddress(addressLine1 = "addressLine1",
+                                             addressLine2 = Some("addressLine2"),
+                                             townOrCity = "Town",
+                                             postCode = Some("PostCode")
                                   )
                                 )
           )
@@ -182,13 +182,14 @@ class RegistrationControllerSpec
                                                                    Some(OrgType.UK_COMPANY),
                                                                  businessRegisteredAddress =
                                                                    Some(
-                                                                     Address(addressLine1 =
-                                                                               "addressLine1",
-                                                                             addressLine2 =
-                                                                               Some("addressLine2"),
-                                                                             townOrCity = "Town",
-                                                                             postCode =
-                                                                               Some("PostCode")
+                                                                     PPTAddress(
+                                                                       addressLine1 =
+                                                                         "addressLine1",
+                                                                       addressLine2 =
+                                                                         Some("addressLine2"),
+                                                                       townOrCity = "Town",
+                                                                       postCode =
+                                                                         Some("PostCode")
                                                                      )
                                                                    )
                                              )
@@ -204,10 +205,10 @@ class RegistrationControllerSpec
                                 email = Some("test@test.com"),
                                 phoneNumber = Some("1234567890"),
                                 address = Some(
-                                  Address(addressLine1 = "addressLine1",
-                                          addressLine2 = Some("addressLine2"),
-                                          townOrCity = "Town",
-                                          postCode = Some("PostCode")
+                                  PPTAddress(addressLine1 = "addressLine1",
+                                             addressLine2 = Some("addressLine2"),
+                                             townOrCity = "Town",
+                                             postCode = Some("PostCode")
                                   )
                                 )
           )

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/repositories/RegistrationRepositorySpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/repositories/RegistrationRepositorySpec.scala
@@ -72,10 +72,10 @@ class RegistrationRepositorySpec
           withOrganisationDetails(
             OrganisationDetails(organisationType = Some(OrgType.UK_COMPANY),
                                 businessRegisteredAddress = Some(
-                                  Address(addressLine1 = "addressLine1",
-                                          addressLine2 = Some("addressLine2"),
-                                          townOrCity = "Town",
-                                          postCode = Some("PostCode")
+                                  PPTAddress(addressLine1 = "addressLine1",
+                                             addressLine2 = Some("addressLine2"),
+                                             townOrCity = "Town",
+                                             postCode = Some("PostCode")
                                   )
                                 )
             )
@@ -150,12 +150,13 @@ class RegistrationRepositorySpec
                                                                email = Some("test@test.com"),
                                                                phoneNumber = Some("1234567890"),
                                                                address = Some(
-                                                                 Address(addressLine1 =
-                                                                           "addressLine1",
-                                                                         addressLine2 =
-                                                                           Some("addressLine2"),
-                                                                         townOrCity = "Town",
-                                                                         postCode = Some("PostCode")
+                                                                 PPTAddress(addressLine1 =
+                                                                              "addressLine1",
+                                                                            addressLine2 =
+                                                                              Some("addressLine2"),
+                                                                            townOrCity = "Town",
+                                                                            postCode =
+                                                                              Some("PostCode")
                                                                  )
                                                                )
                                          )
@@ -166,12 +167,12 @@ class RegistrationRepositorySpec
                                              Some(OrgType.UK_COMPANY),
                                            businessRegisteredAddress =
                                              Some(
-                                               Address(addressLine1 =
-                                                         "addressLine1",
-                                                       addressLine2 =
-                                                         Some("addressLine2"),
-                                                       townOrCity = "Town",
-                                                       postCode = Some("PostCode")
+                                               PPTAddress(addressLine1 =
+                                                            "addressLine1",
+                                                          addressLine2 =
+                                                            Some("addressLine2"),
+                                                          townOrCity = "Town",
+                                                          postCode = Some("PostCode")
                                                )
                                              )
                                          )


### PR DESCRIPTION
Renamed Address => PPTAddress - this is the FE address used in the Registration model
AddressDetails is the "EIS" address used in the subscription create request

Group member addresses are now sent from FE as a PPTAddress for consistency.

FE changes - https://github.com/hmrc/plastic-packaging-tax-registration-frontend/pull/274

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
