### PR TITLE
BAU - stop logging organisation name

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
@@ -20,10 +20,6 @@ import java.time.format.DateTimeFormatter
 import java.time.{ZoneOffset, ZonedDateTime}
 
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.CustomerType.{
-  Individual,
-  Organisation
-}
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.PartnershipTypeEnum.{
   GENERAL_PARTNERSHIP,
   SCOTTISH_PARTNERSHIP
@@ -42,16 +38,7 @@ case class LegalEntityDetails(
   customerDetails: CustomerDetails,
   groupSubscriptionFlag: Boolean,
   partnershipSubscriptionFlag: Boolean = false
-) {
-
-  val name: String = customerDetails.customerType match {
-    case Organisation => customerDetails.organisationDetails.get.organisationName
-    case Individual =>
-      val name = customerDetails.individualDetails.get
-      s"${name.firstName} ${name.lastName}"
-  }
-
-}
+)
 
 object LegalEntityDetails {
 

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
@@ -82,7 +82,7 @@ class SubscriptionController @Inject() (
                                                                              formBundleNumber
                 ) =>
               logger.info(
-                s"Successful PPT subscription for ${pptSubscription.legalEntityDetails.name} with safeId $safeId, " +
+                s"Successful PPT subscription with safeId $safeId, " +
                   s"PPT Reference [$pptReferenceNumber] FormBundleId [$formBundleNumber]"
               )
               for {
@@ -113,9 +113,7 @@ class SubscriptionController @Inject() (
               logPayload(s"PPT Subscription Create failed response for safeId $safeId ",
                          failedSubscriptionResponse
               )
-              logger.warn(
-                s"Failed PPT subscription for ${pptSubscription.legalEntityDetails.name} with safeId $safeId - ${firstError.reason}"
-              )
+              logger.warn(s"Failed PPT subscription with safeId $safeId - ${firstError.reason}")
               Future.successful(Status(statusCode)(failedSubscriptionResponse))
           }
     }


### PR DESCRIPTION
Remove logging of organisation name for successful/failed subscription
Remove un-used "name" method

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
