### PR TITLE
PPTP-1525 : WIP : Migrate Registrations

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/config/AppConfig.scala
@@ -73,4 +73,8 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
     s"$enrolmentStoreProxyHost/enrolment-store-proxy/enrolment-store/enrolments/$enrolmentKey/groups"
 
   val nrsRetries: Seq[FiniteDuration] = config.get[Seq[FiniteDuration]]("nrs.retries")
+
+  val mongoUri = config.get[String]("mongodb.uri")
+  val mongoDb = config.get[String]("mongodb.database")
+  val mongoCollection = config.get[String]("mongodb.collection")
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/config/AppConfig.scala
@@ -74,7 +74,7 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
 
   val nrsRetries: Seq[FiniteDuration] = config.get[Seq[FiniteDuration]]("nrs.retries")
 
-  val mongoUri = config.get[String]("mongodb.uri")
-  val mongoDb = config.get[String]("mongodb.database")
+  val mongoUri        = config.get[String]("mongodb.uri")
+  val mongoDb         = config.get[String]("mongodb.database")
   val mongoCollection = config.get[String]("mongodb.collection")
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/EagerLoaderModule.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/EagerLoaderModule.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.util.migration
+
+import com.google.inject.AbstractModule
+
+class EagerLoaderModule extends AbstractModule {
+
+  override def configure() =
+    bind(classOf[RegistrationUpgrader]).asEagerSingleton()
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/GenericRegistrationRepository.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/GenericRegistrationRepository.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.util.migration
+
+import com.google.inject.{Inject, Singleton}
+import org.mongodb.scala.bson.BsonString
+import org.mongodb.scala.model.Filters.equal
+import org.mongodb.scala.{Document, MongoClient}
+import uk.gov.hmrc.plasticpackagingtaxregistration.config.AppConfig
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class GenericRegistrationRepository @Inject() (appConfig: AppConfig)(implicit
+  ec: ExecutionContext
+) {
+
+  private val client     = MongoClient(appConfig.mongoUri)
+  private val db         = client.getDatabase(appConfig.mongoDb)
+  private val collection = db.getCollection(appConfig.mongoCollection)
+
+  def upgradeRegistrations(upgrader: Document => Document) =
+    collection.find()
+      .toFuture()
+      .map { registrations =>
+        registrations.foreach { reg =>
+          val updatedReg = upgrader(reg)
+          collection.replaceOne(filter(updatedReg.get[BsonString]("id").get), updatedReg).toFuture()
+        }
+      }
+
+  private def filter(id: BsonString) =
+    equal("id", id)
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgrader.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgrader.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxregistration.util.migration
+
+import com.google.inject.{Inject, Singleton}
+import org.mongodb.scala.Document
+import org.mongodb.scala.bson.{BsonDocument, BsonString}
+import play.api.Logger
+
+@Singleton
+class RegistrationUpgrader @Inject() (
+  genericRegistrationRepository: GenericRegistrationRepository
+) {
+
+  private val ORG_DETAILS    = "organisationDetails"
+  private val INCORP_DETAILS = "incorporationDetails"
+  private val REGISTRATION   = "registration"
+  private val BV_STATUS_OLD  = "businessVerificationStatus"
+  private val BV_STATUS_NEW  = "verificationStatus"
+  private val IDS_MATCH      = "identifiersMatch"
+
+  private val logger = Logger(this.getClass)
+
+  // Do it on startup, when the singleton is created. This is done eagerly in 'production' mode.
+  upgradeRegistrations()
+
+  def upgradeRegistrations() = {
+    logger.info("Upgrading any existing in-flight registrations")
+    genericRegistrationRepository.upgradeRegistrations(upgradeRegistration)
+  }
+
+  private def upgradeRegistration(reg: Document): Document = {
+    val organisationDetails: Option[BsonDocument] = reg.get[BsonDocument](ORG_DETAILS)
+    if (organisationDetails.exists(od => od.containsKey(INCORP_DETAILS))) {
+      val incorporationDetails = organisationDetails.get.getDocument(INCORP_DETAILS)
+      if (incorporationDetails.containsKey(REGISTRATION)) {
+        val bvStatus: Option[BsonString] =
+          if (incorporationDetails.containsKey(BV_STATUS_OLD))
+            Some(incorporationDetails.getString(BV_STATUS_OLD))
+          else None
+        val registration = incorporationDetails.getDocument(REGISTRATION)
+
+        if (bvStatus.isDefined) {
+          logger.info(s"Upgrading in-flight registration with id [${reg.getString("id")}]")
+          incorporationDetails.remove(BV_STATUS_OLD)
+          registration.append(BV_STATUS_NEW, bvStatus.get)
+          registration.append(IDS_MATCH, BsonString("true")) // Do it matter what we set this to?
+        } else
+          logger.info(
+            s"Not upgrading compatible in-flight registration with id [${reg.getString("id")}]"
+          )
+      }
+    }
+
+    reg
+  }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgrader.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgrader.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.util.migration
 
 import com.google.inject.{Inject, Singleton}
 import org.mongodb.scala.Document
-import org.mongodb.scala.bson.{BsonDocument, BsonString}
+import org.mongodb.scala.bson.{BsonBoolean, BsonDocument, BsonString}
 import play.api.Logger
 
 @Singleton
@@ -58,7 +58,7 @@ class RegistrationUpgrader @Inject() (
           logger.info(s"Upgrading in-flight registration with id [${reg.getString("id")}]")
           incorporationDetails.remove(BV_STATUS_OLD)
           registration.append(BV_STATUS_NEW, bvStatus.get)
-          registration.append(IDS_MATCH, BsonString("true")) // Do it matter what we set this to?
+          registration.append(IDS_MATCH, BsonBoolean(true)) // Does it matter what we set this to?
         } else
           logger.info(
             s"Not upgrading compatible in-flight registration with id [${reg.getString("id")}]"

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgrader.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgrader.scala
@@ -63,8 +63,14 @@ class RegistrationUpgrader @Inject() (
           logger.info(
             s"Not upgrading compatible in-flight registration with id [${reg.getString("id")}]"
           )
-      }
-    }
+      } else
+        logger.info(
+          s"Not upgrading compatible in-flight registration with id [${reg.getString("id")}]"
+        )
+    } else
+      logger.info(
+        s"Not upgrading compatible in-flight registration with id [${reg.getString("id")}]"
+      )
 
     reg
   }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgraderModule.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/migration/RegistrationUpgraderModule.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.util.migration
 
 import com.google.inject.AbstractModule
 
-class EagerLoaderModule extends AbstractModule {
+class RegistrationUpgraderModule extends AbstractModule {
 
   override def configure() =
     bind(classOf[RegistrationUpgrader]).asEagerSingleton()

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     , "models\\..*"
     , "metrics\\..*"
     , ".*(BuildInfo|Routes|Options).*"
+    , ".*util\\.migration.*"
   ).mkString(";"),
   coverageMinimum := 95,
   coverageFailOnMinimum := true,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -115,6 +115,8 @@ auditing {
 
 mongodb {
   uri = "mongodb://localhost:27017/plastic-packaging-tax-registration"
+  database = "plastic-packaging-tax-registration"
+  collection = "registrations"
   timeToLiveInSeconds =  2592000  #30x24x60x60 = 2592000 - 30 days
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -52,7 +52,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 # Ensure that registration migrations are performed on application startup
-play.modules.enabled += "uk.gov.hmrc.plasticpackagingtaxregistration.util.migration.EagerLoaderModule"
+play.modules.enabled += "uk.gov.hmrc.plasticpackagingtaxregistration.util.migration.RegistrationUpgraderModule"
 
 # Secret key
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,9 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
+# Ensure that registration migrations are performed on application startup
+play.modules.enabled += "uk.gov.hmrc.plasticpackagingtaxregistration.util.migration.EagerLoaderModule"
+
 # Secret key
 # ~~~~~
 # The secret key is used to secure cryptographics functions.

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/config/AppConfigSpec.scala
@@ -31,6 +31,8 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
   private val validAppConfig: Config =
     ConfigFactory.parseString("""
         |mongodb.uri="mongodb://localhost:27017/plastic-packaging-tax"
+        |mongodb.database="plastic-packaging-tax"
+        |mongodb.collection="registrations"
         |mongodb.timeToLiveInSeconds=100
         |microservice.services.auth.host=localhostauth
         |microservice.services.auth.port=9988


### PR DESCRIPTION
Any existing in-flight registrations which are found to be in the older format are automatically upgraded to the newer format on application startup. Note that this is only performed when the RegistrationUpgrader singleton is created; you will need to run the application in 'production' mode for this to happen.
