### PR TITLE
Remove unused Partner.partnerPartershipDetails.partnershipType field

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PartnershipDetails.scala
@@ -56,7 +56,6 @@ object PartnershipBusinessDetails {
 }
 
 case class PartnerPartnershipDetails(
-  partnershipType: PartnerTypeEnum,
   partnershipName: Option[String] = None,
   partnershipBusinessDetails: Option[PartnershipBusinessDetails] = None
 )


### PR DESCRIPTION
### Description of Work carried through

Partner.partnerType is the canonical field for partner type.
Removing this field does not effect the acceptance tests.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
