### PR TITLE
PPTP-1678 : Ensure Registration Changes Backwards Compatible

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -41,7 +41,7 @@ import java.util.UUID
 
 case class Registration(
   id: String,
-  dateOfRegistration: LocalDate = LocalDate.now(),
+  dateOfRegistration: Option[LocalDate] = Some(LocalDate.now()),
   registrationType: Option[RegType] = None,
   groupDetail: Option[GroupDetail] = None,
   incorpJourneyId: Option[String] = None,
@@ -234,7 +234,7 @@ object Registration {
 
     Registration(id = "UPDATE",
                  dateOfRegistration =
-                   LocalDate.parse(subscription.legalEntityDetails.dateOfApplication),
+                   Some(LocalDate.parse(subscription.legalEntityDetails.dateOfApplication)),
                  registrationType = regType,
                  groupDetail = groupDetail,
                  incorpJourneyId = None,

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationRequest.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.models.RegType.RegType
 import java.time.LocalDate
 
 case class RegistrationRequest(
-  dateOfRegistration: LocalDate = LocalDate.now(),
+  dateOfRegistration: Option[LocalDate] = Some(LocalDate.now()),
   registrationType: Option[RegType] = None,
   groupDetail: Option[GroupDetail] = None,
   incorpJourneyId: Option[String],


### PR DESCRIPTION
FE: https://github.com/hmrc/plastic-packaging-tax-registration-frontend/pull/353

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
