### PR TITLE
PPTP-1682 Map Subscription partners back to Registration

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
@@ -24,12 +24,31 @@ case class OrganisationDetails(organisationType: Option[String] = None, organisa
 
   def organisationTypeDisplayName(isGroup: Boolean): OrgType =
     organisationType match {
-      case Some(organisationType)
-          if isGroup && organisationType.equals(
+      case Some(organisationType) =>
+          if (isGroup && organisationType.equals(
             PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString
-          ) =>
-        OrgType.PARTNERSHIP
-      case Some(organisationType) => OrgType.withName(organisationType)
+          )) {
+            OrgType.PARTNERSHIP
+
+          } else {
+            // If OrgType was PARTNERSHIP during registration then Subscription / CustomerDetails.apply has written
+            // the String value of a PartnerTypeEnum here; not an OrgType.
+            // We need to try to map back from PartnerTypeEnum to OrgType
+            val partnerTypeNames =
+            PartnerTypeEnum.partnerTypesWhichRepresentPartnerships.map(_.toString)
+
+            println(organisationType)
+            if (partnerTypeNames.contains(organisationType)) {
+              OrgType.PARTNERSHIP
+
+            } else {
+              OrgType.withName(organisationType)
+
+            }
+          }
+
+      case None =>
+        throw new IllegalStateException("Organisation type absent")
     }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
@@ -25,27 +25,24 @@ case class OrganisationDetails(organisationType: Option[String] = None, organisa
   def organisationTypeDisplayName(isGroup: Boolean): OrgType =
     organisationType match {
       case Some(organisationType) =>
-          if (isGroup && organisationType.equals(
-            PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString
-          )) {
-            OrgType.PARTNERSHIP
-
-          } else {
-            // If OrgType was PARTNERSHIP during registration then Subscription / CustomerDetails.apply has written
-            // the String value of a PartnerTypeEnum here; not an OrgType.
-            // We need to try to map back from PartnerTypeEnum to OrgType
-            val partnerTypeNames =
+        if (
+          isGroup && organisationType.equals(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString)
+        )
+          OrgType.PARTNERSHIP
+        else {
+          // If OrgType was PARTNERSHIP during registration then Subscription / CustomerDetails.apply has written
+          // the String value of a PartnerTypeEnum here; not an OrgType.
+          // We need to try to map back from PartnerTypeEnum to OrgType
+          val partnerTypeNames =
             PartnerTypeEnum.partnerTypesWhichRepresentPartnerships.map(_.toString)
 
-            println(organisationType)
-            if (partnerTypeNames.contains(organisationType)) {
-              OrgType.PARTNERSHIP
+          println(organisationType)
+          if (partnerTypeNames.contains(organisationType))
+            OrgType.PARTNERSHIP
+          else
+            OrgType.withName(organisationType)
 
-            } else {
-              OrgType.withName(organisationType)
-
-            }
-          }
+        }
 
       case None =>
         throw new IllegalStateException("Organisation type absent")

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
@@ -36,7 +36,6 @@ case class OrganisationDetails(organisationType: Option[String] = None, organisa
           val partnerTypeNames =
             PartnerTypeEnum.partnerTypesWhichRepresentPartnerships.map(_.toString)
 
-          println(organisationType)
           if (partnerTypeNames.contains(organisationType))
             OrgType.PARTNERSHIP
           else

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Partner.scala
@@ -45,15 +45,14 @@ object PartnerTypeEnum extends Enumeration {
     Format(Reads.enumNameReads(PartnerTypeEnum), Writes.enumNameWrites)
 
   val partnerTypesWhichRepresentPartnerships = Seq(GENERAL_PARTNERSHIP,
-    LIMITED_PARTNERSHIP,
-    LIMITED_LIABILITY_PARTNERSHIP,
-    SCOTTISH_PARTNERSHIP,
-    SCOTTISH_LIMITED_PARTNERSHIP
+                                                   LIMITED_PARTNERSHIP,
+                                                   LIMITED_LIABILITY_PARTNERSHIP,
+                                                   SCOTTISH_PARTNERSHIP,
+                                                   SCOTTISH_LIMITED_PARTNERSHIP
   )
 
-  val partnerTypesWhichMightContainIncorporationDetails = Seq(
-    UK_COMPANY, OVERSEAS_COMPANY_UK_BRANCH, OVERSEAS_COMPANY_NO_UK_BRANCH
-  )
+  val partnerTypesWhichMightContainIncorporationDetails =
+    Seq(UK_COMPANY, OVERSEAS_COMPANY_UK_BRANCH, OVERSEAS_COMPANY_NO_UK_BRANCH)
 
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Partner.scala
@@ -44,6 +44,13 @@ object PartnerTypeEnum extends Enumeration {
   implicit val format: Format[PartnerTypeEnum] =
     Format(Reads.enumNameReads(PartnerTypeEnum), Writes.enumNameWrites)
 
+  val partnerTypesWhichRepresentPartnerships = Seq(GENERAL_PARTNERSHIP,
+    LIMITED_PARTNERSHIP,
+    LIMITED_LIABILITY_PARTNERSHIP,
+    SCOTTISH_PARTNERSHIP,
+    SCOTTISH_LIMITED_PARTNERSHIP
+  )
+
 }
 
 case class Partner(

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Partner.scala
@@ -51,6 +51,10 @@ object PartnerTypeEnum extends Enumeration {
     SCOTTISH_LIMITED_PARTNERSHIP
   )
 
+  val partnerTypesWhichMightContainIncorporationDetails = Seq(
+    UK_COMPANY, OVERSEAS_COMPANY_UK_BRANCH, OVERSEAS_COMPANY_NO_UK_BRANCH
+  )
+
 }
 
 case class Partner(

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -213,16 +213,20 @@ object Registration {
             None
           }
 
-          val isPartnershipType = partnerType == PartnerTypeEnum.GENERAL_PARTNERSHIP // TODO Awful
+          val isPartnershipType = partnerType == PartnerTypeEnum.GENERAL_PARTNERSHIP || partnerType == PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP // TODO Awful
           val partnerPartnershipDetails = if (isPartnershipType) {
             Some(
               PartnerPartnershipDetails(
-                partnershipName = Option(subscriptionPartner.organisationDetails.organisationName),
+                partnershipName = None,  // Not set in test data; is it used?,
                 partnershipBusinessDetails = Some(
-                  PartnershipBusinessDetails(postcode = "TODO",     // TODO
-                    sautr = "TODO",        // TODO
-                    companyProfile = None, // TODO
-                    registration = None    // TODO
+                  PartnershipBusinessDetails(postcode = subscriptionPartner.customerIdentification2.get, // TODO Naked get,
+                    sautr = subscriptionPartner.customerIdentification1,
+                    companyProfile = Some(CompanyProfile(
+                      companyNumber =  subscriptionPartner.customerIdentification2.get,  // TODO Naked get,
+                      companyName = subscriptionPartner.organisationDetails.organisationName,
+                      companyAddress = IncorporationAddressDetails(),
+                    )),
+                    registration = None    // TODO Unsure what todo about registration
                   )
                 )
               )

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -180,7 +180,7 @@ object Registration {
                                   address = Some(PPTAddress(subscriptionPartner.addressDetails))
             )
 
-          val isIncorporatedType = partnerType == PartnerTypeEnum.UK_COMPANY // TODO This is awful; and comprehensive
+          val isIncorporatedType = PartnerTypeEnum.partnerTypesWhichMightContainIncorporationDetails.contains(partnerType)
           val partnerIncorporationDetails = if(isIncorporatedType) {
             Some(
               IncorporationDetails(
@@ -270,7 +270,6 @@ object Registration {
                                  companyProfile = None
                                )
                              ),
-                             // TODO: rehydrate partners from subscription
                              partners = partners
           )
         )

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -227,9 +227,10 @@ object Registration {
                 "Partner Partnership details required customerIdentification2 which was absent"
               )
             }
+
             Some(
               PartnerPartnershipDetails(
-                partnershipName = None, // Does not appear to be persisted on subscription
+                partnershipName = Some(subscriptionPartner.organisationDetails.organisationName),
                 partnershipBusinessDetails = Some(
                   PartnershipBusinessDetails(postcode = customerIdentification2,
                                              sautr = customerIdentification1,

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -228,7 +228,7 @@ object Registration {
             }
             Some(
               PartnerPartnershipDetails(
-                partnershipName = None, // TODO Not set in test data; is it used?,
+                partnershipName = None, // Does not appear to be persisted on subscription
                 partnershipBusinessDetails = Some(
                   PartnershipBusinessDetails(postcode = customerIdentification2,
                                              sautr = customerIdentification1,
@@ -250,7 +250,7 @@ object Registration {
 
           Partner(
             id =
-              UUID.randomUUID().toString, // TODO Partner.id is not mapped in Subscription so no stable ids or urls
+              UUID.randomUUID().toString, // Partner.id is not mapped in Subscription so ids and urls will not be stable
             partnerType = Some(partnerType),
             contactDetails = Some(partnerContactDetails),
             incorporationDetails = partnerIncorporationDetails,

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -116,26 +116,8 @@ object Registration {
     val organisationType = subscription.legalEntityDetails.customerDetails.customerType match {
       case CustomerType.Individual   => SOLE_TRADER
       case CustomerType.Organisation =>
-        /*
         subscription.legalEntityDetails.customerDetails.organisationDetails.map(
-          _.organisationTypeDisplayName(regType.exists(_.equals(RegType.GROUP)))
-         */
-        subscription.legalEntityDetails.customerDetails.organisationDetails.flatMap(
-          _.organisationType
-        ).flatMap { organisationTypeString =>
-          // If OrgType was PARTNERSHIP during registration then Subscription / CustomerDetails.apply has written
-          // the String value of a PartnerTypeEnum here; not an OrgType.
-          // We need to try to map back from PartnerTypeEnum to OrgType
-          // As the names of these enums overlap the only way we can guess if this was a partnership
-          // is to try and match on the partnershipType.
-          val partnerTypeNames =
-            PartnerTypeEnum.partnerTypesWhichRepresentPartnerships.map(_.toString)
-          if (partnerTypeNames.contains(organisationTypeString))
-            Some(OrgType.PARTNERSHIP)
-          else
-            OrgType.values.find(_.toString == organisationTypeString)
-
-        }.getOrElse(illegalState("Missing organisation type"))
+          _.organisationTypeDisplayName(regType.exists(_.equals(RegType.GROUP)))).getOrElse(illegalState("Missing organisation type"))
     }
 
     val incorporationDetails = organisationType match {
@@ -175,7 +157,7 @@ object Registration {
     }
     val partnershipDetails = organisationType match {
       case OrgType.PARTNERSHIP =>
-        // Subscription presents Partners on the groupPartnershipDetails field
+        // Subscription partners are stored on the groupPartnershipDetails field
         val subscriptionPartners = subscription.groupPartnershipSubscription.map(
           _.groupPartnershipDetails
         ).getOrElse(Seq.empty)
@@ -246,7 +228,7 @@ object Registration {
             }
             Some(
               PartnerPartnershipDetails(
-                partnershipName = None, // Not set in test data; is it used?,
+                partnershipName = None, // TODO Not set in test data; is it used?,
                 partnershipBusinessDetails = Some(
                   PartnershipBusinessDetails(postcode = customerIdentification2,
                                              sautr = customerIdentification1,

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -17,11 +17,25 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.models
 
 import org.joda.time.{DateTime, DateTimeZone}
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{ChangeOfCircumstanceDetails, CustomerType, Subscription}
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.OrgType.{OVERSEAS_COMPANY_UK_BRANCH, OrgType, REGISTERED_SOCIETY, SOLE_TRADER, UK_COMPANY}
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{
+  ChangeOfCircumstanceDetails,
+  CustomerType,
+  Subscription
+}
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.OrgType.{
+  OVERSEAS_COMPANY_UK_BRANCH,
+  OrgType,
+  REGISTERED_SOCIETY,
+  SOLE_TRADER,
+  UK_COMPANY
+}
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.PartnerTypeEnum.PartnerTypeEnum
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.RegType.RegType
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.group.{GroupMember, GroupMemberContactDetails, OrganisationDetails => GroupDetails}
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.group.{
+  GroupMember,
+  GroupMemberContactDetails,
+  OrganisationDetails => GroupDetails
+}
 
 import java.time.LocalDate
 import java.util.UUID

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -114,13 +114,12 @@ object Registration {
                                                )
     )
     val organisationType = subscription.legalEntityDetails.customerDetails.customerType match {
-      case CustomerType.Individual => SOLE_TRADER
-      /* case CustomerType.Organisation =>
+      case CustomerType.Individual   => SOLE_TRADER
+      case CustomerType.Organisation =>
+        /*
         subscription.legalEntityDetails.customerDetails.organisationDetails.map(
           _.organisationTypeDisplayName(regType.exists(_.equals(RegType.GROUP)))
-        ).getOrElse(illegalState("Missing organisation type"))
-       */
-      case CustomerType.Organisation =>
+         */
         subscription.legalEntityDetails.customerDetails.organisationDetails.flatMap(
           _.organisationType
         ).flatMap { organisationTypeString =>

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -180,7 +180,7 @@ object Registration {
                                   address = Some(PPTAddress(subscriptionPartner.addressDetails))
             )
 
-          val isIncorporatedType = partnerType == PartnerTypeEnum.UK_COMPANY // TODO This is awful
+          val isIncorporatedType = partnerType == PartnerTypeEnum.UK_COMPANY // TODO This is awful; and comprehensive
           val partnerIncorporationDetails = if(isIncorporatedType) {
             Some(
               IncorporationDetails(
@@ -213,7 +213,7 @@ object Registration {
             None
           }
 
-          val isPartnershipType = partnerType == PartnerTypeEnum.GENERAL_PARTNERSHIP || partnerType == PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP // TODO Awful
+          val isPartnershipType = PartnerTypeEnum.partnerTypesWhichRepresentPartnerships.contains(partnerType)
           val partnerPartnershipDetails = if (isPartnershipType) {
             Some(
               PartnerPartnershipDetails(

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -114,10 +114,11 @@ object Registration {
                                                )
     )
     val organisationType = subscription.legalEntityDetails.customerDetails.customerType match {
-      case CustomerType.Individual   => SOLE_TRADER
+      case CustomerType.Individual => SOLE_TRADER
       case CustomerType.Organisation =>
         subscription.legalEntityDetails.customerDetails.organisationDetails.map(
-          _.organisationTypeDisplayName(regType.exists(_.equals(RegType.GROUP)))).getOrElse(illegalState("Missing organisation type"))
+          _.organisationTypeDisplayName(regType.exists(_.equals(RegType.GROUP)))
+        ).getOrElse(illegalState("Missing organisation type"))
     }
 
     val incorporationDetails = organisationType match {

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -169,16 +169,19 @@ object Registration {
 
           val isIncorporatedType = PartnerTypeEnum.partnerTypesWhichMightContainIncorporationDetails.contains(partnerType)
           val customerIdentification1 = subscriptionPartner.customerIdentification1
-          val customerIdentification2: Option[String] = subscriptionPartner.customerIdentification2
+          val mayBeCustomerIdentification2 = subscriptionPartner.customerIdentification2
 
           val partnerIncorporationDetails = if(isIncorporatedType) {
+            val customerIdentification2 = mayBeCustomerIdentification2.getOrElse{
+              throw new IllegalStateException("Incorporation details required customerIdentification2 which was absent")
+            }
             Some(
               IncorporationDetails(
                 companyNumber = customerIdentification1,
                 companyName =
                   subscriptionPartner.organisationDetails.organisationName,
                 ctutr =
-                  customerIdentification2.get, // TODO Naked get
+                  customerIdentification2,
                 companyAddress = IncorporationAddressDetails(),
                 registration = None
               )
@@ -205,14 +208,17 @@ object Registration {
 
           val isPartnershipType = PartnerTypeEnum.partnerTypesWhichRepresentPartnerships.contains(partnerType)
           val partnerPartnershipDetails = if (isPartnershipType) {
+            val customerIdentification2 = mayBeCustomerIdentification2.getOrElse{
+              throw new IllegalStateException("Partner Partnership details required customerIdentification2 which was absent")
+            }
             Some(
               PartnerPartnershipDetails(
                 partnershipName = None,  // Not set in test data; is it used?,
                 partnershipBusinessDetails = Some(
-                  PartnershipBusinessDetails(postcode = customerIdentification2.get, // TODO Naked get,
+                  PartnershipBusinessDetails(postcode = customerIdentification2,
                     sautr = customerIdentification1,
                     companyProfile = Some(CompanyProfile(
-                      companyNumber =  customerIdentification2.get,  // TODO Naked get,
+                      companyNumber =  customerIdentification2,
                       companyName = subscriptionPartner.organisationDetails.organisationName,
                       companyAddress = IncorporationAddressDetails(),
                     )),

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -226,7 +226,7 @@ object Registration {
                       companyName = subscriptionPartner.organisationDetails.organisationName,
                       companyAddress = IncorporationAddressDetails(),
                     )),
-                    registration = None    // TODO Unsure what todo about registration
+                    registration = None
                   )
                 )
               )

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
@@ -211,7 +211,7 @@ trait RegistrationTestData {
             soleTraderDetails = Some(
               SoleTraderIncorporationDetails(firstName = "Steve",
                                              lastName = "Knight",
-                                             dateOfBirth = None,
+                                             dateOfBirth = Some("1971-02-03"),
                                              ninoOrTrn = "1234567890XYZ",
                                              sautr = Some("123ABC456DEF"),
                                              registration = Some(

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/RegistrationTestData.scala
@@ -123,7 +123,11 @@ trait RegistrationTestData {
                            )
                          ),
                          partners =
-                           Seq(aUkCompanyPartner(), aSoleTraderPartner(), aPartnershipPartner())
+                           Seq(aUkCompanyPartner(),
+                               aSoleTraderPartner(),
+                               aPartnershipPartner(),
+                               aNonIncorpPartnershipPartner()
+                           )
       )
     )
   )
@@ -144,7 +148,11 @@ trait RegistrationTestData {
                            )
                          ),
                          partners =
-                           Seq(aUkCompanyPartner(), aSoleTraderPartner(), aPartnershipPartner())
+                           Seq(aUkCompanyPartner(),
+                               aSoleTraderPartner(),
+                               aPartnershipPartner(),
+                               aNonIncorpPartnershipPartner()
+                           )
       )
     )
   )
@@ -279,6 +287,44 @@ trait RegistrationTestData {
                                       PPTAddress(addressLine1 = "12 New Lane",
                                                  townOrCity = "Leeds",
                                                  postCode = Some("LS1 1RE")
+                                      )
+                                    )
+              )
+            )
+    )
+
+  protected def aNonIncorpPartnershipPartner(): Partner =
+    Partner(partnerType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP),
+            partnerPartnershipDetails = Some(
+              PartnerPartnershipDetails(partnershipName = Some("Scottish Plastic Partners"),
+                                        partnershipBusinessDetails = Some(
+                                          PartnershipBusinessDetails(sautr = "23947GDFD22",
+                                                                     postcode = "HD1 7TE",
+                                                                     companyProfile = None,
+                                                                     registration = Some(
+                                                                       RegistrationDetails(
+                                                                         identifiersMatch = true,
+                                                                         verificationStatus =
+                                                                           Some("VERIFIED"),
+                                                                         registrationStatus =
+                                                                           "REGISTERED",
+                                                                         registeredBusinessPartnerId =
+                                                                           Some("XM454345")
+                                                                       )
+                                                                     )
+                                          )
+                                        )
+              )
+            ),
+            contactDetails = Some(
+              PartnerContactDetails(firstName = Some("Jonas"),
+                                    lastName = Some("Jenkson"),
+                                    emailAddress = Some("jonas@spp.com"),
+                                    phoneNumber = Some("0765123765"),
+                                    address = Some(
+                                      PPTAddress(addressLine1 = "The Big House",
+                                                 townOrCity = "Huddersfield",
+                                                 postCode = Some("HD2 2JD")
                                       )
                                     )
               )

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetailsSpec.scala
@@ -1,0 +1,34 @@
+package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.plasticpackagingtaxregistration.models.{OrgType, PartnerTypeEnum}
+
+class OrganisationDetailsSpec  extends AnyWordSpec with Matchers{
+
+  "OrganisationDetails" should {
+
+    "mapOrganisationTypeStringsToEnums" in {
+      OrganisationDetails(organisationType = Some("UkCompany"), organisationName = "My organisation").
+        organisationTypeDisplayName(isGroup = false) mustBe OrgType.UK_COMPANY
+
+      OrganisationDetails(organisationType = Some("Partnership"), organisationName = "My organisation").
+        organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
+    }
+
+    "return partnership organisation type if a partner type enum string is found instead of an organisation type" in {
+      OrganisationDetails(organisationType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP.toString), organisationName = "My organisation").
+        organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
+
+      OrganisationDetails(organisationType = Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString), organisationName = "My organisation").
+        organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
+    }
+
+    "treat LLPs as partnerships if they are part of a group" in {
+        // TODO why this is different to the above non group case?
+      OrganisationDetails(organisationType = Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString), organisationName = "My organisation").
+        organisationTypeDisplayName(isGroup = true) mustBe OrgType.PARTNERSHIP
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetailsSpec.scala
@@ -1,33 +1,56 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription
 
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.{OrgType, PartnerTypeEnum}
 
-class OrganisationDetailsSpec  extends AnyWordSpec with Matchers{
+class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
 
   "OrganisationDetails" should {
 
     "mapOrganisationTypeStringsToEnums" in {
-      OrganisationDetails(organisationType = Some("UkCompany"), organisationName = "My organisation").
-        organisationTypeDisplayName(isGroup = false) mustBe OrgType.UK_COMPANY
+      OrganisationDetails(organisationType = Some("UkCompany"),
+                          organisationName = "My organisation"
+      ).organisationTypeDisplayName(isGroup = false) mustBe OrgType.UK_COMPANY
 
-      OrganisationDetails(organisationType = Some("Partnership"), organisationName = "My organisation").
-        organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
+      OrganisationDetails(organisationType = Some("Partnership"),
+                          organisationName = "My organisation"
+      ).organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
     }
 
     "return partnership organisation type if a partner type enum string is found instead of an organisation type" in {
-      OrganisationDetails(organisationType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP.toString), organisationName = "My organisation").
-        organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
+      OrganisationDetails(organisationType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP.toString),
+                          organisationName = "My organisation"
+      ).organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
 
-      OrganisationDetails(organisationType = Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString), organisationName = "My organisation").
-        organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
+      OrganisationDetails(organisationType =
+                            Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString),
+                          organisationName = "My organisation"
+      ).organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
     }
 
     "treat LLPs as partnerships if they are part of a group" in {
-        // TODO why this is different to the above non group case?
-      OrganisationDetails(organisationType = Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString), organisationName = "My organisation").
-        organisationTypeDisplayName(isGroup = true) mustBe OrgType.PARTNERSHIP
+      // TODO why this is different to the above non group case?
+      OrganisationDetails(organisationType =
+                            Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP.toString),
+                          organisationName = "My organisation"
+      ).organisationTypeDisplayName(isGroup = true) mustBe OrgType.PARTNERSHIP
     }
   }
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
@@ -94,7 +94,9 @@ class SubscriptionSpec
         assertCommonDetails(subscription, Some(10000), isPartnership = true)
 
         subscription.legalEntityDetails.customerDetails.customerType mustBe CustomerType.Organisation
-        subscription.legalEntityDetails.customerDetails.organisationDetails.flatMap(_.organisationType) mustBe Some("GeneralPartnership")
+        subscription.legalEntityDetails.customerDetails.organisationDetails.flatMap(
+          _.organisationType
+        ) mustBe Some("GeneralPartnership")
 
         mustHaveValidGeneralPartnershipLegalEntityDetails(subscription)
         mustHaveValidPartners(subscription,

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
@@ -93,11 +93,6 @@ class SubscriptionSpec
 
         assertCommonDetails(subscription, Some(10000), isPartnership = true)
 
-        subscription.legalEntityDetails.customerDetails.customerType mustBe CustomerType.Organisation
-        subscription.legalEntityDetails.customerDetails.organisationDetails.flatMap(
-          _.organisationType
-        ) mustBe Some("GeneralPartnership")
-
         mustHaveValidGeneralPartnershipLegalEntityDetails(subscription)
         mustHaveValidPartners(subscription,
                               registration.organisationDetails.partnershipDetails.get.partners

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/SubscriptionSpec.scala
@@ -92,6 +92,10 @@ class SubscriptionSpec
         val subscription = Subscription(registration, isSubscriptionUpdate = false)
 
         assertCommonDetails(subscription, Some(10000), isPartnership = true)
+
+        subscription.legalEntityDetails.customerDetails.customerType mustBe CustomerType.Organisation
+        subscription.legalEntityDetails.customerDetails.organisationDetails.flatMap(_.organisationType) mustBe Some("GeneralPartnership")
+
         mustHaveValidGeneralPartnershipLegalEntityDetails(subscription)
         mustHaveValidPartners(subscription,
                               registration.organisationDetails.partnershipDetails.get.partners

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -118,6 +118,18 @@ class RegistrationSpec
 
     }
 
+    "convert from general partner subscription" in {
+
+      val generalPartnershipRegistration =
+        aRegistration(withOrganisationDetails(pptGeneralPartnershipDetails),
+                      withPrimaryContactDetails(pptPrimaryContactDetails),
+                      withLiabilityDetails(pptLiabilityDetails)
+        )
+
+      assertConversion(generalPartnershipRegistration)
+
+    }
+
     "convert partnership details when mapping from a subscription" in {
       val partnershipDetails = pptGeneralPartnershipDetails.partnershipDetails.map(
         _.copy(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP)
@@ -284,11 +296,10 @@ class RegistrationSpec
     }
 
     def assertConversion(registration: Registration) = {
-      val existingSubscription = Subscription(registration, isSubscriptionUpdate = false)
 
+      val existingSubscription   = Subscription(registration, isSubscriptionUpdate = false)
       val rehydratedRegistration = Registration(existingSubscription)
-
-      val updatedSubscription = Subscription(rehydratedRegistration, isSubscriptionUpdate = false)
+      val updatedSubscription    = Subscription(rehydratedRegistration, isSubscriptionUpdate = false)
 
       updatedSubscription mustBe existingSubscription
     }

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -132,19 +132,21 @@ class RegistrationSpec
 //    }
 
     "convert partnership details when mapping from a subscription" in {
-      val generalPartnershipRegistration =
-        aRegistration(withOrganisationDetails(pptGeneralPartnershipDetails),
+      val partnershipDetails = pptGeneralPartnershipDetails.partnershipDetails.map(_.copy(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP))  // To force out hardcoded GENERAL_PARTNERSHIP
+      val partnershipRegistration = {
+        aRegistration(withOrganisationDetails(pptGeneralPartnershipDetails.copy(partnershipDetails = partnershipDetails)),
                       withPrimaryContactDetails(pptPrimaryContactDetails),
                       withLiabilityDetails(pptLiabilityDetails)
         )
+      }
 
-      generalPartnershipRegistration.organisationDetails.organisationType mustBe Some(
+      partnershipRegistration.organisationDetails.organisationType mustBe Some(
         OrgType.PARTNERSHIP
       )
-      generalPartnershipRegistration.organisationDetails.partnershipDetails.map(
+      partnershipRegistration.organisationDetails.partnershipDetails.map(
         _.partnershipType
-      ) mustBe Some(PartnerTypeEnum.GENERAL_PARTNERSHIP)
-      val existingSubscription = Subscription(generalPartnershipRegistration)
+      ) mustBe Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP)
+      val existingSubscription = Subscription(partnershipRegistration)
 
       val rehydratedRegistration = Registration(existingSubscription)
 
@@ -153,17 +155,18 @@ class RegistrationSpec
       val rehydratedPartnershipDetails =
         rehydratedRegistration.organisationDetails.partnershipDetails.get
 
-      rehydratedPartnershipDetails.partners.size mustBe generalPartnershipRegistration.organisationDetails.partnershipDetails.get.partners.size
+      rehydratedPartnershipDetails.partnershipType mustBe PartnerTypeEnum.SCOTTISH_PARTNERSHIP
+      rehydratedPartnershipDetails.partners.size mustBe partnershipRegistration.organisationDetails.partnershipDetails.get.partners.size
       rehydratedPartnershipDetails.partners.map(
         _.partnerType
-      ) mustBe generalPartnershipRegistration.organisationDetails.partnershipDetails.get.partners.map(
+      ) mustBe partnershipRegistration.organisationDetails.partnershipDetails.get.partners.map(
         _.partnerType
       )
 
       val rehydratedNominatedPartner               = rehydratedPartnershipDetails.partners.head
       val rehydratedNominatedPartnerContactDetails = rehydratedNominatedPartner.contactDetails
       val nominatedPartner =
-        generalPartnershipRegistration.organisationDetails.partnershipDetails.get.partners.head
+        partnershipRegistration.organisationDetails.partnershipDetails.get.partners.head
       rehydratedNominatedPartnerContactDetails mustBe nominatedPartner.contactDetails
 
       rehydratedNominatedPartner.incorporationDetails.get.companyAddress mustBe IncorporationAddressDetails() // Subscription does not map anything into these fields

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -222,15 +222,13 @@ class RegistrationSpec
           _.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)
         ).get
 
-      println(partnershipPartner.partnerPartnershipDetails)
-      println(rehydratedPartnershipPartnerPartner.partnerPartnershipDetails)
-
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.nonEmpty mustBe true
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
         _.partnershipBusinessDetails
       ).nonEmpty mustBe true
 
-      // partnershipBusinessDetails
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipName) mustBe Some("Partners in Plastic")
+
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
         _.partnershipBusinessDetails
       ).map(_.postcode) mustBe

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -226,9 +226,10 @@ class RegistrationSpec
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyName) mustBe
         partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyName)
 
-      // TODO postcode and companyNumber probably overwrite each other in the id2 field; can't be round tripped
+      // TODO For a partnership customerIdentification1 is the partnershipBusinessDetails.sautr and customerIdentification2 is the partnershipBusinessDetails.postcode
+      // Company number and not be recovered from the Subscription.
       //rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber) mustBe
-     //   partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber)
+      //  partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber)
 
       // None of these partners have RegistrationDetails set because we think this field is just
       // an artifact of top level entire classes been reused to represent partner details.

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -132,6 +132,22 @@ class RegistrationSpec
 //
 //    }
 
+    "convert partnership details when mapping from a subscription" in {
+      val generalPartnershipRegistration =
+             aRegistration(withOrganisationDetails(pptGeneralPartnershipDetails),
+                           withPrimaryContactDetails(pptPrimaryContactDetails),
+                           withLiabilityDetails(pptLiabilityDetails)
+           )
+
+      generalPartnershipRegistration.organisationDetails.organisationType mustBe Some(OrgType.PARTNERSHIP)
+      generalPartnershipRegistration.organisationDetails.partnershipDetails.map(_.partnershipType) mustBe Some(PartnerTypeEnum.GENERAL_PARTNERSHIP)
+      val existingSubscription = Subscription(generalPartnershipRegistration)
+
+      val rehydratedRegistration = Registration(existingSubscription)
+
+      rehydratedRegistration.isPartnership mustBe true
+    }
+
     "convert from UK company group subscription" in {
 
       val ukCompanyGroupRegistration =

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -132,17 +132,19 @@ class RegistrationSpec
 //    }
 
     "convert partnership details when mapping from a subscription" in {
-      val partnershipDetails = pptGeneralPartnershipDetails.partnershipDetails.map(_.copy(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP))  // To force out hardcoded GENERAL_PARTNERSHIP
-      val partnershipRegistration = {
-        aRegistration(withOrganisationDetails(pptGeneralPartnershipDetails.copy(partnershipDetails = partnershipDetails)),
-                      withPrimaryContactDetails(pptPrimaryContactDetails),
-                      withLiabilityDetails(pptLiabilityDetails)
+      val partnershipDetails = pptGeneralPartnershipDetails.partnershipDetails.map(
+        _.copy(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP)
+      ) // To force out hardcoded GENERAL_PARTNERSHIP
+      val partnershipRegistration =
+        aRegistration(
+          withOrganisationDetails(
+            pptGeneralPartnershipDetails.copy(partnershipDetails = partnershipDetails)
+          ),
+          withPrimaryContactDetails(pptPrimaryContactDetails),
+          withLiabilityDetails(pptLiabilityDetails)
         )
-      }
 
-      partnershipRegistration.organisationDetails.organisationType mustBe Some(
-        OrgType.PARTNERSHIP
-      )
+      partnershipRegistration.organisationDetails.organisationType mustBe Some(OrgType.PARTNERSHIP)
       partnershipRegistration.organisationDetails.partnershipDetails.map(
         _.partnershipType
       ) mustBe Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP)

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -213,7 +213,7 @@ class RegistrationSpec
         _.lastName
       ) mustBe soleTraderPartner.soleTraderDetails.map(_.lastName)
 
-      // There is no where map date of birth on individualDetails so it cannot be round tripped
+      // There is no way to map date of birth on individualDetails so it cannot be round tripped
       soleTraderPartner.soleTraderDetails.flatMap(_.dateOfBirth).nonEmpty mustBe true
       rehydratedSoleTraderPartner.soleTraderDetails.flatMap(_.dateOfBirth).isEmpty mustBe true
 
@@ -267,15 +267,9 @@ class RegistrationSpec
           _.companyProfile
         ).map(_.companyName)
 
-      // TODO For a partnership customerIdentification1 is the partnershipBusinessDetails.sautr and customerIdentification2 is the partnershipBusinessDetails.postcode
-      // Company number and not be recovered from the Subscription.
-      //rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber) mustBe
-      //  partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber)
-
       // None of these partners have RegistrationDetails set because we think this field is just
       // an artifact of top level entire classes been reused to represent partner details.
       // Therefore none of these partners will have RegistrationDetails set.
-      // These classes could be replaced with a partner specific class to remove this confusion
       // Explicit gets to confirm we're asserting in the right fields for each partner class
       rehydratedNominatedPartner.incorporationDetails.get.registration mustBe None
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.get.partnershipBusinessDetails.get.registration mustBe None

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -134,7 +134,7 @@ class RegistrationSpec
     "convert partnership details when mapping from a subscription" in {
       val partnershipDetails = pptGeneralPartnershipDetails.partnershipDetails.map(
         _.copy(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP)
-      ) // To force out hardcoded GENERAL_PARTNERSHIP
+      )
       val partnershipRegistration =
         aRegistration(
           withOrganisationDetails(
@@ -148,7 +148,7 @@ class RegistrationSpec
       partnershipRegistration.organisationDetails.partnershipDetails.map(
         _.partnershipType
       ) mustBe Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP)
-      val existingSubscription = Subscription(partnershipRegistration)
+      val existingSubscription = Subscription(partnershipRegistration, false)
 
       val rehydratedRegistration = Registration(existingSubscription)
 
@@ -168,7 +168,7 @@ class RegistrationSpec
       // Check the first partner in detail
       val nominatedPartner =
         partnershipRegistration.organisationDetails.partnershipDetails.get.partners.head
-      val rehydratedNominatedPartner               = rehydratedPartnershipDetails.partners.head
+      val rehydratedNominatedPartner = rehydratedPartnershipDetails.partners.head
 
       // Partner type
       rehydratedNominatedPartner.partnerType mustBe Some(PartnerTypeEnum.UK_COMPANY)
@@ -177,12 +177,18 @@ class RegistrationSpec
 
       // Incorporated entities will have populated the incorporationDetails field.
       rehydratedNominatedPartner.incorporationDetails.nonEmpty mustBe true
-      rehydratedNominatedPartner.incorporationDetails.map(_.companyName) mustBe nominatedPartner.incorporationDetails.map(_.companyName)
-      rehydratedNominatedPartner.incorporationDetails.map(_.companyNumber) mustBe nominatedPartner.incorporationDetails.map(_.companyNumber)
-      rehydratedNominatedPartner.incorporationDetails.map(_.ctutr) mustBe nominatedPartner.incorporationDetails.map(_.ctutr)
+      rehydratedNominatedPartner.incorporationDetails.map(
+        _.companyName
+      ) mustBe nominatedPartner.incorporationDetails.map(_.companyName)
+      rehydratedNominatedPartner.incorporationDetails.map(
+        _.companyNumber
+      ) mustBe nominatedPartner.incorporationDetails.map(_.companyNumber)
+      rehydratedNominatedPartner.incorporationDetails.map(
+        _.ctutr
+      ) mustBe nominatedPartner.incorporationDetails.map(_.ctutr)
 
       // IncorporationAddressDetails does not appear to be mapped to Subscription; or used for anything in the backend
-      nominatedPartner.incorporationDetails.get.companyAddress mustBe IncorporationAddressDetails() // Subscription does not map anything into these fields
+      nominatedPartner.incorporationDetails.get.companyAddress mustBe IncorporationAddressDetails()           // Subscription does not map anything into these fields
       rehydratedNominatedPartner.incorporationDetails.get.companyAddress mustBe IncorporationAddressDetails() // Subscription does not map anything into these fields
 
       //  Incorporated entities will not have populated the soleTraderDetails or partnerPartnershipDetails fields.
@@ -191,40 +197,76 @@ class RegistrationSpec
 
       // Examine a rehydrated sole trader
       // We should assert all of the sole trade details fields here
-      val soleTraderPartner =  partnershipRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.SOLE_TRADER)).get
-      val rehydratedSoleTraderPartner =  rehydratedRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.SOLE_TRADER)).get
+      val soleTraderPartner =
+        partnershipRegistration.organisationDetails.partnershipDetails.get.partners.find(
+          _.partnerType.contains(PartnerTypeEnum.SOLE_TRADER)
+        ).get
+      val rehydratedSoleTraderPartner =
+        rehydratedRegistration.organisationDetails.partnershipDetails.get.partners.find(
+          _.partnerType.contains(PartnerTypeEnum.SOLE_TRADER)
+        ).get
 
       rehydratedSoleTraderPartner.soleTraderDetails.nonEmpty mustBe true
-      rehydratedSoleTraderPartner.soleTraderDetails.map(_.firstName) mustBe soleTraderPartner.soleTraderDetails.map(_.firstName)
-      rehydratedSoleTraderPartner.soleTraderDetails.map(_.lastName) mustBe soleTraderPartner.soleTraderDetails.map(_.lastName)
+      rehydratedSoleTraderPartner.soleTraderDetails.map(
+        _.firstName
+      ) mustBe soleTraderPartner.soleTraderDetails.map(_.firstName)
+      rehydratedSoleTraderPartner.soleTraderDetails.map(
+        _.lastName
+      ) mustBe soleTraderPartner.soleTraderDetails.map(_.lastName)
 
       // There is no where map date of birth on individualDetails so it cannot be round tripped
       soleTraderPartner.soleTraderDetails.flatMap(_.dateOfBirth).nonEmpty mustBe true
       rehydratedSoleTraderPartner.soleTraderDetails.flatMap(_.dateOfBirth).isEmpty mustBe true
 
-      rehydratedSoleTraderPartner.soleTraderDetails.map(_.ninoOrTrn) mustBe soleTraderPartner.soleTraderDetails.map(_.ninoOrTrn)
-      rehydratedSoleTraderPartner.soleTraderDetails.map(_.sautr) mustBe soleTraderPartner.soleTraderDetails.map(_.sautr)
+      rehydratedSoleTraderPartner.soleTraderDetails.map(
+        _.ninoOrTrn
+      ) mustBe soleTraderPartner.soleTraderDetails.map(_.ninoOrTrn)
+      rehydratedSoleTraderPartner.soleTraderDetails.map(
+        _.sautr
+      ) mustBe soleTraderPartner.soleTraderDetails.map(_.sautr)
 
       // Examine a partner type partner to investigate the mapping of partnerPartnershipDetails.
-      val partnershipPartner =  partnershipRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)).get
-      val rehydratedPartnershipPartnerPartner =  rehydratedRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)).get
+      val partnershipPartner =
+        partnershipRegistration.organisationDetails.partnershipDetails.get.partners.find(
+          _.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)
+        ).get
+      val rehydratedPartnershipPartnerPartner =
+        rehydratedRegistration.organisationDetails.partnershipDetails.get.partners.find(
+          _.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)
+        ).get
 
       println(partnershipPartner.partnerPartnershipDetails)
       println(rehydratedPartnershipPartnerPartner.partnerPartnershipDetails)
 
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.nonEmpty mustBe true
-      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).nonEmpty mustBe true
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
+        _.partnershipBusinessDetails
+      ).nonEmpty mustBe true
 
       // partnershipBusinessDetails
-      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.postcode) mustBe
-        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.postcode)
-      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.sautr) mustBe
-        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.sautr)
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
+        _.partnershipBusinessDetails
+      ).map(_.postcode) mustBe
+        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(
+          _.postcode
+        )
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
+        _.partnershipBusinessDetails
+      ).map(_.sautr) mustBe
+        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(
+          _.sautr
+        )
 
       // partnershipBusinessDetails / companyProfile
-      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).nonEmpty mustBe true
-      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyName) mustBe
-        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyName)
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
+        _.partnershipBusinessDetails
+      ).flatMap(_.companyProfile).nonEmpty mustBe true
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
+        _.partnershipBusinessDetails
+      ).flatMap(_.companyProfile).map(_.companyName) mustBe
+        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(
+          _.companyProfile
+        ).map(_.companyName)
 
       // TODO For a partnership customerIdentification1 is the partnershipBusinessDetails.sautr and customerIdentification2 is the partnershipBusinessDetails.postcode
       // Company number and not be recovered from the Subscription.

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -118,19 +118,6 @@ class RegistrationSpec
 
     }
 
-    // TODO: reintroduce when we can deal with partnership registration -> subscription -> registration
-//    "convert from general partner subscription" in {
-//
-//      val generalPartnershipRegistration =
-//        aRegistration(withOrganisationDetails(pptGeneralPartnershipDetails),
-//                      withPrimaryContactDetails(pptPrimaryContactDetails),
-//                      withLiabilityDetails(pptLiabilityDetails)
-//        )
-//
-//      assertConversion(generalPartnershipRegistration)
-//
-//    }
-
     "convert partnership details when mapping from a subscription" in {
       val partnershipDetails = pptGeneralPartnershipDetails.partnershipDetails.map(
         _.copy(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP)

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -189,7 +189,7 @@ class RegistrationSpec
       rehydratedNominatedPartner.incorporationDetails.get.companyAddress mustBe IncorporationAddressDetails() // Subscription does not map anything into these fields
 
       // TODO IncorporationDetails.Registration does what?
-      rehydratedNominatedPartner.incorporationDetails.get.registration mustBe None
+      rehydratedNominatedPartner.incorporationDetails.flatMap(_.registration) mustBe None
 
       //  Incorporated entities will not have populated the soleTraderDetails or partnerPartnershipDetails fields.
       rehydratedNominatedPartner.soleTraderDetails mustBe None
@@ -214,9 +214,31 @@ class RegistrationSpec
       // TODO We don't know what todo about Registration
       rehydratedSoleTraderPartner.soleTraderDetails.flatMap(_.registration) mustBe None
 
-      //rehydratedNominatedPartner.partnerPartnershipDetails.flatMap(_.partnershipName) mustBe Some(
-       // nominatedPartner.name
-     // )
+      // Examine a partner type partner to investigate the mapping of partnerPartnershipDetails.
+      val partnershipPartner =  partnershipRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)).get
+      val rehydratedPartnershipPartnerPartner =  rehydratedRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)).get
+
+      println(partnershipPartner.partnerPartnershipDetails)
+      println(rehydratedPartnershipPartnerPartner.partnerPartnershipDetails)
+
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.nonEmpty mustBe true
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).nonEmpty mustBe true
+
+
+      // partnershipBusinessDetails
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.postcode) mustBe
+        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.postcode)
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.sautr) mustBe
+        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.sautr)
+
+      // partnershipBusinessDetails / companyProfile
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).nonEmpty mustBe true
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyName) mustBe
+        partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyName)
+
+      // TODO postcode and companyNumber probably overwrite each other in the id2 field; can't be round tripped
+      //rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber) mustBe
+     //   partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber)
     }
 
     "convert from UK company group subscription" in {

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -227,7 +227,9 @@ class RegistrationSpec
         _.partnershipBusinessDetails
       ).nonEmpty mustBe true
 
-      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipName) mustBe Some("Partners in Plastic")
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
+        _.partnershipName
+      ) mustBe Some("Partners in Plastic")
 
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(
         _.partnershipBusinessDetails

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -175,9 +175,6 @@ class RegistrationSpec
       // Partner contact details
       rehydratedNominatedPartner.contactDetails mustBe nominatedPartner.contactDetails
 
-      // Need to understand what is mapped into the optional nested fields.
-      // incorporationDetails, partnerPartnershipDetails soleTraderDetails.
-
       // Incorporated entities will have populated the incorporationDetails field.
       rehydratedNominatedPartner.incorporationDetails.nonEmpty mustBe true
       rehydratedNominatedPartner.incorporationDetails.map(_.companyName) mustBe nominatedPartner.incorporationDetails.map(_.companyName)
@@ -187,9 +184,6 @@ class RegistrationSpec
       // IncorporationAddressDetails does not appear to be mapped to Subscription; or used for anything in the backend
       nominatedPartner.incorporationDetails.get.companyAddress mustBe IncorporationAddressDetails() // Subscription does not map anything into these fields
       rehydratedNominatedPartner.incorporationDetails.get.companyAddress mustBe IncorporationAddressDetails() // Subscription does not map anything into these fields
-
-      // TODO IncorporationDetails.Registration does what?
-      rehydratedNominatedPartner.incorporationDetails.flatMap(_.registration) mustBe None
 
       //  Incorporated entities will not have populated the soleTraderDetails or partnerPartnershipDetails fields.
       rehydratedNominatedPartner.soleTraderDetails mustBe None
@@ -211,9 +205,6 @@ class RegistrationSpec
       rehydratedSoleTraderPartner.soleTraderDetails.map(_.ninoOrTrn) mustBe soleTraderPartner.soleTraderDetails.map(_.ninoOrTrn)
       rehydratedSoleTraderPartner.soleTraderDetails.map(_.sautr) mustBe soleTraderPartner.soleTraderDetails.map(_.sautr)
 
-      // TODO We don't know what todo about Registration
-      rehydratedSoleTraderPartner.soleTraderDetails.flatMap(_.registration) mustBe None
-
       // Examine a partner type partner to investigate the mapping of partnerPartnershipDetails.
       val partnershipPartner =  partnershipRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)).get
       val rehydratedPartnershipPartnerPartner =  rehydratedRegistration.organisationDetails.partnershipDetails.get.partners.find(_.partnerType.contains(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)).get
@@ -223,7 +214,6 @@ class RegistrationSpec
 
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.nonEmpty mustBe true
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).nonEmpty mustBe true
-
 
       // partnershipBusinessDetails
       rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).map(_.postcode) mustBe
@@ -239,6 +229,15 @@ class RegistrationSpec
       // TODO postcode and companyNumber probably overwrite each other in the id2 field; can't be round tripped
       //rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber) mustBe
      //   partnershipPartner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails).flatMap(_.companyProfile).map(_.companyNumber)
+
+      // None of these partners have RegistrationDetails set because we think this field is just
+      // an artifact of top level entire classes been reused to represent partner details.
+      // Therefore none of these partners will have RegistrationDetails set.
+      // These classes could be replaced with a partner specific class to remove this confusion
+      // Explicit gets to confirm we're asserting in the right fields for each partner class
+      rehydratedNominatedPartner.incorporationDetails.get.registration mustBe None
+      rehydratedPartnershipPartnerPartner.partnerPartnershipDetails.get.partnershipBusinessDetails.get.registration mustBe None
+      rehydratedSoleTraderPartner.soleTraderDetails.get.registration mustBe None
     }
 
     "convert from UK company group subscription" in {


### PR DESCRIPTION
### Description of Work carried through

When unmashalling an EMTP Subscription back into a Registration, attempt to re hydrate a Partnership's Partners from Subscription GroupPartnershipSubscription

![Screenshot from 2022-02-14 11-43-32](https://user-images.githubusercontent.com/95688374/153858277-1d8721a3-f710-493a-8ddc-e84470c81a88.png)

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
