### PR TITLE
Pptp 1765 Set hard coded mandatory change of circumstances on subscription updates

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnector.scala
@@ -22,13 +22,7 @@ import play.api.Logger
 import play.api.http.Status
 import play.api.libs.json.Json._
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{
-  HeaderCarrier,
-  HttpClient,
-  HttpResponse,
-  NotFoundException,
-  UpstreamErrorResponse
-}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
 import uk.gov.hmrc.plasticpackagingtaxregistration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription._
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.create.{
@@ -39,7 +33,6 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscri
 }
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.{
   ETMPSubscriptionStatusResponse,
-  SubscriptionStatus,
   SubscriptionStatusResponse
 }
 
@@ -184,21 +177,11 @@ class SubscriptionsConnector @Inject() (
   def updateSubscription(pptReference: String, subscription: Subscription)(implicit
     hc: HeaderCarrier
   ): Future[SubscriptionResponse] = {
-
-    // A mandatory field is required when calling the subscription variation API
-    val updateToDetailsChangeOfCircumstance = subscription.changeOfCircumstanceDetails.getOrElse(
-      ChangeOfCircumstanceDetails(changeOfCircumstance =
-        ChangeOfCircumstance.UPDATE_TO_DETAILS.toString
-      )
-    ).copy(changeOfCircumstance = ChangeOfCircumstance.UPDATE_TO_DETAILS.toString)
-    val updatedSubscription =
-      subscription.copy(changeOfCircumstanceDetails = Some(updateToDetailsChangeOfCircumstance))
-
     val timer: Timer.Context = metrics.defaultRegistry.timer("ppt.subscription.update.timer").time()
     val correlationIdHeader: (String, String) =
       correlationIdHeaderName -> UUID.randomUUID().toString
     httpClient.PUT[Subscription, HttpResponse](url = appConfig.subscriptionUpdateUrl(pptReference),
-                                               body = updatedSubscription,
+                                               body = subscription,
                                                headers = headers :+ correlationIdHeader
     )
       .andThen { case _ => timer.stop() }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
@@ -22,11 +22,7 @@ import play.api.libs.json._
 import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.EISError
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.{
-  ChangeOfCircumstance,
-  ChangeOfCircumstanceDetails,
-  Subscription
-}
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.Subscription
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.create.{
   SubscriptionCreateWithEnrolmentAndNrsStatusesResponse,
   SubscriptionFailureResponseWithStatusCode,
@@ -87,25 +83,10 @@ class SubscriptionController @Inject() (
   def update(pptReference: String): Action[RegistrationRequest] =
     authenticator.authorisedAction(authenticator.parsingJson[RegistrationRequest]) {
       implicit request =>
-        val updatedRegistration = request.body.toRegistration(request.registrationId)
-
-        val updatedSubscription = Subscription(updatedRegistration, isSubscriptionUpdate = true)
-
-        // A mandatory field is required when calling the subscription variation API
-        val updateToDetailsChangeOfCircumstance =
-          updatedSubscription.changeOfCircumstanceDetails.getOrElse(
-            ChangeOfCircumstanceDetails(changeOfCircumstance =
-              ChangeOfCircumstance.UPDATE_TO_DETAILS.toString
-            )
-          ).copy(changeOfCircumstance = ChangeOfCircumstance.UPDATE_TO_DETAILS.toString)
-        val updatedSubscriptionWithChangeOfCircumstance =
-          updatedSubscription.copy(changeOfCircumstanceDetails =
-            Some(updateToDetailsChangeOfCircumstance)
-          )
-
-        subscriptionsConnector.updateSubscription(pptReference,
-                                                  updatedSubscriptionWithChangeOfCircumstance
-        ).flatMap {
+        val updatedRegistration: Registration = request.body.toRegistration(request.registrationId)
+        val updatedSubscription: Subscription =
+          Subscription(updatedRegistration, isSubscriptionUpdate = true)
+        subscriptionsConnector.updateSubscription(pptReference, updatedSubscription).flatMap {
           case response @ SubscriptionSuccessfulResponse(pptReferenceNumber, _, formBundleNumber) =>
             for {
               nrsResponse <- notifyNRS(request, updatedRegistration, response)


### PR DESCRIPTION
### Description of Work carried through

Set hard coded mandatory change of circumstances on subscription updates.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
