### PR TITLE
PPTP-1803 : RegWithoutID Fix

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
@@ -116,7 +116,8 @@ object LegalEntityDetails {
                        customerDetails = CustomerDetails(pptOrganisationDetails),
                        groupSubscriptionFlag = isGroup,
                        partnershipSubscriptionFlag = isPartnership,
-                       regWithoutIDFlag = pptOrganisationDetails.regWithoutIDFlag
+                       regWithoutIDFlag =
+                         if (isGroup) Some(true) else pptOrganisationDetails.regWithoutIDFlag
     )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetails.scala
@@ -56,14 +56,16 @@ object LegalEntityDetails {
 
   implicit def apply(
     pptOrganisationDetails: PPTOrganisationDetails,
-    isGroup: Boolean
+    isGroup: Boolean,
+    isUpdate: Boolean
   ): LegalEntityDetails =
     pptOrganisationDetails.organisationType match {
       case Some(OrgType.SOLE_TRADER) =>
         pptOrganisationDetails.soleTraderDetails.map { details =>
           updateLegalEntityDetails(customerIdentification1 = details.ninoOrTrn,
                                    customerIdentification2 = details.sautr,
-                                   pptOrganisationDetails = pptOrganisationDetails
+                                   pptOrganisationDetails = pptOrganisationDetails,
+                                   isUpdate = isUpdate
           )
         }.getOrElse(throw new Exception("Individual details are required"))
       case Some(OrgType.PARTNERSHIP) =>
@@ -75,6 +77,7 @@ object LegalEntityDetails {
                                        customerIdentification2 =
                                          partnershipDetails.customerIdentification2,
                                        pptOrganisationDetails = pptOrganisationDetails,
+                                       isUpdate = isUpdate,
                                        isGroup = isGroup,
                                        isPartnership = partnershipDetails.partners.nonEmpty
               )
@@ -88,7 +91,8 @@ object LegalEntityDetails {
           updateLegalEntityDetails(customerIdentification1 = details.companyNumber,
                                    customerIdentification2 = Some(details.ctutr),
                                    pptOrganisationDetails = pptOrganisationDetails,
-                                   isGroup
+                                   isUpdate = isUpdate,
+                                   isGroup = isGroup
           )
 
         }.getOrElse(throw new IllegalStateException("Incorporation details are required"))
@@ -106,6 +110,7 @@ object LegalEntityDetails {
     customerIdentification1: String,
     customerIdentification2: Option[String],
     pptOrganisationDetails: PPTOrganisationDetails,
+    isUpdate: Boolean,
     isGroup: Boolean = false,
     isPartnership: Boolean = false
   ): LegalEntityDetails =
@@ -117,7 +122,8 @@ object LegalEntityDetails {
                        groupSubscriptionFlag = isGroup,
                        partnershipSubscriptionFlag = isPartnership,
                        regWithoutIDFlag =
-                         if (isGroup) Some(true) else pptOrganisationDetails.regWithoutIDFlag
+                         if (isUpdate && isGroup) Some(true)
+                         else pptOrganisationDetails.regWithoutIDFlag
     )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/Subscription.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/Subscription.scala
@@ -59,7 +59,10 @@ object Subscription {
     Subscription(changeOfCircumstanceDetails = changeOfCircumstanceDetails,
                  processingDate = registration.processingDate,
                  legalEntityDetails =
-                   LegalEntityDetails(registration.organisationDetails, isGroup(registration)),
+                   LegalEntityDetails(registration.organisationDetails,
+                                      isGroup = isGroup(registration),
+                                      isUpdate = isSubscriptionUpdate
+                   ),
                  principalPlaceOfBusinessDetails = PrincipalPlaceOfBusinessDetails(registration),
                  primaryContactDetails = PrimaryContactDetails(registration),
                  businessCorrespondenceDetails = BusinessCorrespondenceDetails(registration),

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/Registration.scala
@@ -300,6 +300,10 @@ object Registration {
         )
       case _ => None
     }
+
+    def isGroupSubscription(subscription: Subscription) =
+      subscription.legalEntityDetails.groupSubscriptionFlag
+
     val organisationDetails = OrganisationDetails(organisationType = Some(organisationType),
                                                   businessRegisteredAddress =
                                                     Some(
@@ -312,7 +316,15 @@ object Registration {
                                                   partnershipDetails = partnershipDetails,
                                                   incorporationDetails = incorporationDetails,
                                                   subscriptionStatus = None,
-                                                  regWithoutIDFlag =
+                                                  regWithoutIDFlag = if (
+                                                    isGroupSubscription(subscription)
+                                                  )
+                                                    subscription.groupPartnershipSubscription.flatMap(
+                                                      _.groupPartnershipDetails.headOption.flatMap(
+                                                        _.regWithoutIDFlag
+                                                      )
+                                                    )
+                                                  else
                                                     subscription.legalEntityDetails.regWithoutIDFlag
     )
     val liabilityDetails = LiabilityDetails(

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
@@ -131,7 +131,8 @@ trait SubscriptionTestData {
     OrganisationDetails(Some("UkCompany"), "Plastics Ltd"),
     IndividualDetails(None, "Kevin", None, "Durant"),
     AddressDetails("2-3 Scala Street", "London", None, None, Some("W1T 2HN"), "GB"),
-    ContactDetails("test@test.com", "02034567890", None)
+    ContactDetails("test@test.com", "02034567890", None),
+    regWithoutIDFlag = Some(false)
   )
 
   protected val groupPartnershipDetailsMember: GroupPartnershipDetails = GroupPartnershipDetails(
@@ -147,7 +148,8 @@ trait SubscriptionTestData {
                    Some("postcode"),
                    "GB"
     ),
-    ContactDetails("member@email.com", "0987-456789", None)
+    ContactDetails("member@email.com", "0987-456789", None),
+    regWithoutIDFlag = Some(true)
   )
 
   protected val groupPartnershipSubscription: GroupPartnershipSubscription =

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/CustomerDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/CustomerDetailsSpec.scala
@@ -120,7 +120,8 @@ class CustomerDetailsSpec extends AnyWordSpec with Matchers with RegistrationTes
                 )
               )
             ),
-            isGroup = false
+            isGroup = false,
+            isUpdate = false
           )
         }
       }
@@ -135,7 +136,8 @@ class CustomerDetailsSpec extends AnyWordSpec with Matchers with RegistrationTes
                 )
               )
             ),
-            isGroup = false
+            isGroup = false,
+            isUpdate = false
           )
         }
       }

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/LegalEntityDetailsSpec.scala
@@ -27,8 +27,9 @@ import java.time.format.DateTimeFormatter
 class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with RegistrationTestData {
   "LegalEntityDetails" should {
     "build successfully" when {
-      "subscribing an organisation" in {
-        val legalEntityDetails = LegalEntityDetails(pptIncorporationDetails, false)
+      "subscribing a single entity" in {
+        val legalEntityDetails =
+          LegalEntityDetails(pptIncorporationDetails, isGroup = false, isUpdate = false)
         legalEntityDetails.dateOfApplication mustBe now(UTC).format(
           DateTimeFormatter.ofPattern("yyyy-MM-dd")
         )
@@ -47,12 +48,14 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
       }
 
       "subscribing a group" in {
-        val legalEntityDetails = LegalEntityDetails(pptIncorporationDetails, true)
+        val legalEntityDetails =
+          LegalEntityDetails(pptIncorporationDetails, isGroup = true, isUpdate = false)
         legalEntityDetails.groupSubscriptionFlag mustBe true
       }
 
       "subscribing an individual" in {
-        val legalEntityDetails = LegalEntityDetails(pptSoleTraderDetails, false)
+        val legalEntityDetails =
+          LegalEntityDetails(pptSoleTraderDetails, isGroup = false, isUpdate = false)
         legalEntityDetails.dateOfApplication mustBe now(UTC).format(
           DateTimeFormatter.ofPattern("yyyy-MM-dd")
         )
@@ -70,7 +73,8 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
         legalEntityDetails.customerDetails.individualDetails.get.middleName mustBe None
       }
       "subscribing a general partnership" in {
-        val legalEntityDetails = LegalEntityDetails(pptGeneralPartnershipDetails, false)
+        val legalEntityDetails =
+          LegalEntityDetails(pptGeneralPartnershipDetails, isGroup = false, isUpdate = false)
         legalEntityDetails.dateOfApplication mustBe now(UTC).format(
           DateTimeFormatter.ofPattern("yyyy-MM-dd")
         )
@@ -90,7 +94,8 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
         legalEntityDetails.customerDetails.organisationDetails.get.organisationName mustBe pptGeneralPartnershipDetails.partnershipDetails.get.partnershipName.get
       }
       "subscribing a scottish partnership" in {
-        val legalEntityDetails = LegalEntityDetails(pptScottishPartnershipDetails, false)
+        val legalEntityDetails =
+          LegalEntityDetails(pptScottishPartnershipDetails, isGroup = false, isUpdate = false)
         legalEntityDetails.dateOfApplication mustBe now(UTC).format(
           DateTimeFormatter.ofPattern("yyyy-MM-dd")
         )
@@ -110,7 +115,8 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
         legalEntityDetails.customerDetails.organisationDetails.get.organisationName mustBe pptScottishPartnershipDetails.partnershipDetails.get.partnershipName.get
       }
       "subscribing a limited liability partnership" in {
-        val legalEntityDetails = LegalEntityDetails(pptLimitedLiabilityDetails, false)
+        val legalEntityDetails =
+          LegalEntityDetails(pptLimitedLiabilityDetails, isGroup = false, isUpdate = false)
         legalEntityDetails.dateOfApplication mustBe now(UTC).format(
           DateTimeFormatter.ofPattern("yyyy-MM-dd")
         )
@@ -131,6 +137,20 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
       }
     }
 
+    "do NOT set regWithoutIDFlag on group registration creation" in {
+      LegalEntityDetails(pptIncorporationDetails,
+                         isGroup = true,
+                         isUpdate = false
+      ).regWithoutIDFlag mustBe None
+    }
+
+    "always set regWithoutIDFlag to true on group registration update (variation)" in {
+      LegalEntityDetails(pptIncorporationDetails,
+                         isGroup = true,
+                         isUpdate = true
+      ).regWithoutIDFlag mustBe Some(true)
+    }
+
     "throw an exception" when {
       "organisation type is 'None'" in {
         intercept[Exception] {
@@ -140,19 +160,28 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
 
       "corporate and incorporation details are missing" in {
         intercept[Exception] {
-          LegalEntityDetails(pptIncorporationDetails.copy(incorporationDetails = None), false)
+          LegalEntityDetails(pptIncorporationDetails.copy(incorporationDetails = None),
+                             isGroup = false,
+                             isUpdate = false
+          )
         }
       }
 
       "sole trader and sole trader details are missing" in {
         intercept[Exception] {
-          LegalEntityDetails(pptSoleTraderDetails.copy(soleTraderDetails = None), false)
+          LegalEntityDetails(pptSoleTraderDetails.copy(soleTraderDetails = None),
+                             isGroup = false,
+                             isUpdate = false
+          )
         }
       }
 
       "partnership and partnership details are missing" in {
         intercept[Exception] {
-          LegalEntityDetails(pptGeneralPartnershipDetails.copy(partnershipDetails = None), false)
+          LegalEntityDetails(pptGeneralPartnershipDetails.copy(partnershipDetails = None),
+                             isGroup = false,
+                             isUpdate = false
+          )
         }
       }
 
@@ -167,7 +196,8 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
                 )
               )
             ),
-            false
+            isGroup = false,
+            isUpdate = false
           )
         }
       }
@@ -182,7 +212,8 @@ class LegalEntityDetailsSpec extends AnyWordSpec with Matchers with Registration
                 )
               )
             ),
-            false
+            isGroup = false,
+            isUpdate = false
           )
         }
       }

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/RegistrationSpec.scala
@@ -57,7 +57,7 @@ class RegistrationSpec
         )
       val rehydratedRegistration = Registration(amendedGroupSubscription)
 
-      val updatedSubscription = Subscription(rehydratedRegistration, isSubscriptionUpdate = false)
+      val updatedSubscription = Subscription(rehydratedRegistration, isSubscriptionUpdate = true)
 
       updatedSubscription mustBe amendedGroupSubscription
 


### PR DESCRIPTION
Since LegalEntityDetails.regWithoutID is always true for group subscriptions, we can (when creating a Registration from a Subscription) use the Registration equivalent field (OrganisationDetails.regWithoutIDFlag) to hold the value for the representative group member (the first GroupPartnershipDetails instance). When re-creating the Subscription from the amended Registration we will set LegalEntityDetails.regWithoutID to true (since it's always this value) and use the value in OrganisationDetails.regWithoutIDFlag to populate the representative group member (the first GroupPartnershipDetails instance). Other group members can then be populated from the GroupMember instances.

See https://jira.tools.tax.service.gov.uk/browse/PPTP-1803 for a schematic showing this.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [ ] Links to dependencies have been included (BE/FE work) - N/A
 - [ ] User Acceptance Tests (UAT) were run locally and have passed - N/A
