### PR TITLE
PPTP-1854 Registration backend end points which are specific to a given ppt enrolment should be authed for that enrolment

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionController.scala
@@ -73,7 +73,7 @@ class SubscriptionController @Inject() (
     }
 
   def get(pptReference: String): Action[AnyContent] =
-    authenticator.authorisedAction(parse.default) { implicit request =>
+    authenticator.authorisedAction(parse.default, Some(pptReference)) { implicit request =>
       subscriptionsConnector.getSubscription(pptReference).map {
         case Right(response)       => Ok(Registration(response))
         case Left(errorStatusCode) => new Status(errorStatusCode)
@@ -81,7 +81,9 @@ class SubscriptionController @Inject() (
     }
 
   def update(pptReference: String): Action[RegistrationRequest] =
-    authenticator.authorisedAction(authenticator.parsingJson[RegistrationRequest]) {
+    authenticator.authorisedAction(authenticator.parsingJson[RegistrationRequest],
+                                   Some(pptReference)
+    ) {
       implicit request =>
         val updatedRegistration: Registration = request.body.toRegistration(request.registrationId)
         val updatedSubscription: Subscription =

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
@@ -17,17 +17,8 @@
 package uk.gov.hmrc.plasticpackagingtaxregistration.models
 
 import play.api.libs.json._
-import uk.gov.hmrc.auth.core.InternalError
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatus.Status
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.OrgType.{OrgType, PARTNERSHIP}
-import uk.gov.hmrc.plasticpackagingtaxregistration.models.PartnerTypeEnum.{
-  LIMITED_LIABILITY_PARTNERSHIP,
-  SCOTTISH_LIMITED_PARTNERSHIP,
-  SCOTTISH_PARTNERSHIP,
-  SOLE_TRADER
-}
-
-import java.io
 
 object OrgType extends Enumeration {
   type OrgType = Value

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/actions/AuthenticatorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/actions/AuthenticatorSpec.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.plasticpackagingtaxregistration.actions
 
-import org.scalatest.EitherValues
+import org.mockito.Mockito.reset
+import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -32,7 +33,7 @@ import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import scala.concurrent.ExecutionContext
 
 class AuthenticatorSpec
-    extends AnyWordSpec with Matchers with MockitoSugar with AuthTestSupport
+    extends AnyWordSpec with Matchers with MockitoSugar with AuthTestSupport with BeforeAndAfterEach
     with DefaultAwaitTimeout with EitherValues {
 
   private val mcc           = stubMessagesControllerComponents()
@@ -40,12 +41,17 @@ class AuthenticatorSpec
   private val request       = FakeRequest()
   private val authenticator = new Authenticator(mockAuthConnector, mcc)(ExecutionContext.global)
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockAuthConnector)
+  }
+
   "Authenticator" should {
     "return 401 unauthorised " when {
       "if user is not authorised" in {
         withUnauthorizedUser(InsufficientConfidenceLevel("User not authorised"))
 
-        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier()(hc, request))
 
         result.left.value.statusCode mustBe UNAUTHORIZED
       }
@@ -55,7 +61,7 @@ class AuthenticatorSpec
       "when returning the InternalId results in an exception" in {
         withUnauthorizedUser(new Exception("Something went wrong"))
 
-        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier()(hc, request))
 
         result.left.value.statusCode mustBe INTERNAL_SERVER_ERROR
       }
@@ -65,14 +71,14 @@ class AuthenticatorSpec
       "user group not available" in {
         withAuthorizedUser(newUser(), userGroup = None)
 
-        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier()(hc, request))
 
         result.left.value.statusCode mustBe UNAUTHORIZED
       }
       "user credentials not available" in {
         withAuthorizedUser(newUser(), userCredentials = None)
 
-        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier()(hc, request))
 
         result.left.value.statusCode mustBe UNAUTHORIZED
       }
@@ -82,13 +88,29 @@ class AuthenticatorSpec
       "internalId, credentials and group identifier is available" in {
         withAuthorizedUser(newUser())
 
-        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier(hc, request))
+        val result = await(authenticator.authorisedWithInternalIdAndGroupIdentifier()(hc, request))
 
         result.value.registrationId mustBe userInternalId
         result.value.userId mustBe userCredentialsId
         result.value.groupId mustBe userGroupIdentifier
       }
+
+      "has requested ppt enrolment, internalId, credentials and group identifier is available" in {
+        withAuthorizedUser(newEnrolledUser(), userPptReference = Some(userEnrolledPptReference))
+
+        val result = await(
+          authenticator.authorisedWithInternalIdAndGroupIdentifier(pptReference =
+            Some(userEnrolledPptReference)
+          )(hc, request)
+        )
+
+        result.value.registrationId mustBe userInternalId
+        result.value.userId mustBe userCredentialsId
+        result.value.groupId mustBe userGroupIdentifier
+      }
+
     }
+
   }
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
@@ -70,8 +70,6 @@ trait AuthTestSupport extends MockitoSugar {
       ArgumentMatchers.eq(EmptyPredicate)
     }
 
-    println(expectedAuthPredicateMatcher)
-
     when(
       mockAuthConnector.authorise(
         expectedAuthPredicateMatcher,
@@ -99,10 +97,7 @@ trait AuthTestSupport extends MockitoSugar {
       newEnrolments(
         newEnrolment(KeyValue.pptServiceName, KeyValue.etmpPptReferenceKey, pptEnrolmentId)
       )
-
-    val user = newUser(enrolments = Some(pptEnrolment(userEnrolledPptReference)))
-    println("!!!!!!!!E " + user)
-    user
+    newUser(enrolments = Some(pptEnrolment(userEnrolledPptReference)))
   }
 
   def newEnrolments(enrolment: Enrolment*): Enrolments =

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/AuthTestSupport.scala
@@ -16,17 +16,18 @@
 
 package uk.gov.hmrc.plasticpackagingtaxregistration.base
 
-import org.mockito.ArgumentMatchers
+import org.mockito.{ArgumentMatcher, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Logger
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
+import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{internalId, _}
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name, Retrieval, _}
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.KeyValue
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.SignedInUser
 import uk.gov.hmrc.plasticpackagingtaxregistration.services.nrs.NonRepudiationService.NonRepudiationIdentityRetrievals
 
@@ -37,22 +38,48 @@ trait AuthTestSupport extends MockitoSugar {
   lazy val mockAuthConnector: AuthConnector = mock[AuthConnector]
   lazy val mockLogger: Logger               = mock[Logger]
 
-  val userInternalId      = "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"
-  val userGroupIdentifier = "testGroupId-419b91bc-8f97-4b5e-85ef-d58d4cfd4bb8"
-  val userCredentialsId   = "12342370495723"
+  val userInternalId           = "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"
+  val userGroupIdentifier      = "testGroupId-419b91bc-8f97-4b5e-85ef-d58d4cfd4bb8"
+  val userCredentialsId        = "12342370495723"
+  val userEnrolledPptReference = "XMPPT00000000001"
 
   def withAuthorizedUser(
     user: SignedInUser = newUser(),
     userGroup: Option[String] = Some(userGroupIdentifier),
-    userCredentials: Option[Credentials] = Some(Credentials(userCredentialsId, "GovernmentGateway"))
-  ): Unit =
+    userCredentials: Option[Credentials] = Some(
+      Credentials(userCredentialsId, "GovernmentGateway")
+    ),
+    userPptReference: Option[String] = None
+  ): Unit = {
+
+    def enrolmentWithDelegatedAuth(pptReference: String) =
+      Enrolment(KeyValue.pptServiceName).withIdentifier(KeyValue.etmpPptReferenceKey,
+                                                        pptReference
+      ).withDelegatedAuthRule("ppt-auth")
+
+    def pptEnrollmentMatcherFor(pptReference: String): ArgumentMatcher[Predicate] = {
+      (p: Predicate) =>
+        p == enrolmentWithDelegatedAuth(pptReference) && user.enrolments.getEnrolment(
+          KeyValue.pptServiceName
+        ).isDefined
+    }
+
+    val expectedAuthPredicateMatcher = userPptReference.map { pptReference =>
+      ArgumentMatchers.argThat(pptEnrollmentMatcherFor(pptReference))
+    }.getOrElse {
+      ArgumentMatchers.eq(EmptyPredicate)
+    }
+
+    println(expectedAuthPredicateMatcher)
+
     when(
       mockAuthConnector.authorise(
-        any(),
+        expectedAuthPredicateMatcher,
         ArgumentMatchers.eq(internalId and credentials and groupIdentifier)
       )(any(), any())
     )
       .thenReturn(Future.successful(new ~(new ~(user.internalId, userCredentials), userGroup)))
+  }
 
   def withUnauthorizedUser(error: Throwable): Unit =
     when(mockAuthConnector.authorise(any(), any())(any(), any())).thenReturn(Future.failed(error))
@@ -66,6 +93,17 @@ trait AuthTestSupport extends MockitoSugar {
                  Some(AffinityGroup.Organisation),
                  enrolments.getOrElse(Enrolments(Set()))
     )
+
+  def newEnrolledUser(): SignedInUser = {
+    def pptEnrolment(pptEnrolmentId: String) =
+      newEnrolments(
+        newEnrolment(KeyValue.pptServiceName, KeyValue.etmpPptReferenceKey, pptEnrolmentId)
+      )
+
+    val user = newUser(enrolments = Some(pptEnrolment(userEnrolledPptReference)))
+    println("!!!!!!!!E " + user)
+    user
+  }
 
   def newEnrolments(enrolment: Enrolment*): Enrolments =
     Enrolments(enrolment.toSet)

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/base/data/SubscriptionTestData.scala
@@ -16,12 +16,9 @@
 
 package uk.gov.hmrc.plasticpackagingtaxregistration.base.data
 
-import java.time.ZoneOffset.UTC
-import java.time.ZonedDateTime.now
-import java.time.format.DateTimeFormatter
-
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
+import uk.gov.hmrc.plasticpackagingtaxregistration.base.AuthTestSupport
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.EISError
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription._
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscription.create.{
@@ -40,11 +37,15 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscri
 }
 import uk.gov.hmrc.plasticpackagingtaxregistration.models.OrgType
 
-trait SubscriptionTestData {
+import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime.now
+import java.time.format.DateTimeFormatter
+
+trait SubscriptionTestData extends AuthTestSupport {
 
   protected val safeNumber   = "123456"
   protected val idType       = "ZPPT"
-  protected val pptReference = "XMPPT0000000001"
+  protected val pptReference = userEnrolledPptReference
 
   protected val subscriptionStatusResponse_HttpGet: FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest("GET", "/subscriptions/status/" + safeNumber)

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/SubscriptionsConnectorISpec.scala
@@ -35,11 +35,7 @@ import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscri
   SubscriptionSuccessfulResponse
 }
 import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.ETMPSubscriptionStatus.NO_FORM_BUNDLE_FOUND
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatus.{
-  NOT_SUBSCRIBED,
-  UNKNOWN
-}
-import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatusResponse
+import uk.gov.hmrc.plasticpackagingtaxregistration.connectors.models.eis.subscriptionStatus.SubscriptionStatus.NOT_SUBSCRIBED
 
 import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.UUID

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/controllers/SubscriptionControllerSpec.scala
@@ -236,7 +236,9 @@ class SubscriptionControllerSpec
 
   "Get subscription" should {
     "return expected details" in {
-      withAuthorizedUser()
+      withAuthorizedUser(user = newEnrolledUser(),
+                         userPptReference = Some(userEnrolledPptReference)
+      )
       mockGetSubscription(ukLimitedCompanySubscription)
 
       val result: Future[Result] = route(app, subscriptionResponse_HttpGet).get
@@ -259,7 +261,9 @@ class SubscriptionControllerSpec
 
     "pass through exceptions" when {
       "an exception occurs during the subscription call" in {
-        withAuthorizedUser()
+        withAuthorizedUser(user = newEnrolledUser(),
+                           userPptReference = Some(userEnrolledPptReference)
+        )
         mockGetSubscriptionFailure(new IllegalStateException("BANG!"))
 
         val result: Future[Result] = route(app, subscriptionResponse_HttpGet).get
@@ -284,7 +288,9 @@ class SubscriptionControllerSpec
     "update details" when {
 
       "should decorate updates with change of circumstances details" in {
-        withAuthorizedUser(user = newUser())
+        withAuthorizedUser(user = newEnrolledUser(),
+                           userPptReference = Some(userEnrolledPptReference)
+        )
         val nrSubmissionId = "nrSubmissionId"
         when(
           mockNonRepudiationService.submitNonRepudiation(any(), any(), any(), any())(any())
@@ -394,7 +400,9 @@ class SubscriptionControllerSpec
 
     "return 500" when {
       "EIS/IF subscription call returns an exception" in {
-        withAuthorizedUser()
+        withAuthorizedUser(user = newEnrolledUser(),
+                           userPptReference = Some(userEnrolledPptReference)
+        )
         mockSubscriptionUpdateFailure(new RuntimeException("error"))
         intercept[Exception] {
           val result: Future[Result] =


### PR DESCRIPTION
### Description of Work carried through

Registration backend end points which are specific to a given ppt enrolment should be authed for that enrolment.

Prevents cross account access.

Authenticator introduces an option parameter to enforce this. Applies to Subscription end points. Include support for an Agent delegated auth.


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
