### PR TITLE
Pptp 1993

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetails.scala
@@ -36,7 +36,7 @@ object AddressDetails {
                    addressLine2 = address.eisAddressLines._2,
                    addressLine3 = address.eisAddressLines._3,
                    addressLine4 = address.eisAddressLines._4,
-                   postalCode = address.postCode,
+                   postalCode = address.postCode.filter(_.trim != ""),
                    countryCode = address.countryCode
     )
 

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
@@ -64,7 +64,7 @@ object BusinessCorrespondenceDetails {
                                       addressLine2 = address.eisAddressLines._2,
                                       addressLine3 = address.eisAddressLines._3,
                                       addressLine4 = address.eisAddressLines._4,
-                                      postalCode = address.postCode,
+                                      postalCode = address.postCode.filter(_.trim != ""),
                                       countryCode = address.countryCode
     )
 

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddress.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddress.scala
@@ -32,12 +32,14 @@ case class PPTAddress(
 ) {
 
   val eisAddressLines: (String, String, Option[String], Option[String]) = {
-    val list: Seq[String] = Seq(Some(addressLine1), addressLine2, addressLine3, Some(townOrCity)).collect {
-      case Some(x) if x.trim != "" => Some(x)
-    }.flatten
+    val list: Seq[String] =
+      Seq(Some(addressLine1), addressLine2, addressLine3, Some(townOrCity)).collect {
+        case Some(x) if x.trim != "" => Some(x)
+      }.flatten
 
     (list.lift(0).getOrElse(" "), list.lift(1).getOrElse(" "), list.lift(2), list.lift(3))
   }
+
 }
 
 object PPTAddress {

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddress.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddress.scala
@@ -32,10 +32,12 @@ case class PPTAddress(
 ) {
 
   val eisAddressLines: (String, String, Option[String], Option[String]) = {
-    val list = Seq(Some(addressLine1), addressLine2, addressLine3, Some(townOrCity)).flatten
-    (list.head, list(1), list.lift(2), list.lift(3))
-  }
+    val list: Seq[String] = Seq(Some(addressLine1), addressLine2, addressLine3, Some(townOrCity)).collect {
+      case Some(x) if x.trim != "" => Some(x)
+    }.flatten
 
+    (list.lift(0).getOrElse(" "), list.lift(1).getOrElse(" "), list.lift(2), list.lift(3))
+  }
 }
 
 object PPTAddress {

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
@@ -27,13 +27,12 @@ class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTest
     "map from PPT Address" when {
       "provided with missing town or city" in {
         val addressDetails = AddressDetails(
-          PPTAddress(
-            addressLine1 = "Line 1",
-            addressLine2 = None,
-            addressLine3 = Some("Basingstoke"),
-            townOrCity = "",
-            postCode = Some("ZZ1 1ZZ"),
-            countryCode = "GB"
+          PPTAddress(addressLine1 = "Line 1",
+                     addressLine2 = None,
+                     addressLine3 = Some("Basingstoke"),
+                     townOrCity = "",
+                     postCode = Some("ZZ1 1ZZ"),
+                     countryCode = "GB"
           )
         )
 
@@ -45,16 +44,14 @@ class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTest
         addressDetails.countryCode mustBe "GB"
       }
 
-
       "provided with some empty strings" in {
         val addressDetails = AddressDetails(
-          PPTAddress(
-            addressLine1 = "Line 1",
-            addressLine2 = Some(""),
-            addressLine3 = Some("Line 3"),
-            townOrCity = "",
-            postCode = Some(""),
-            countryCode = "GB"
+          PPTAddress(addressLine1 = "Line 1",
+                     addressLine2 = Some(""),
+                     addressLine3 = Some("Line 3"),
+                     townOrCity = "",
+                     postCode = Some(""),
+                     countryCode = "GB"
           )
         )
 
@@ -68,14 +65,14 @@ class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTest
 
       "provided with all empty strings" in {
         val addressDetails = AddressDetails(
-          PPTAddress(
-            addressLine1 = "",
-            addressLine2 = Some(""),
-            addressLine3 = Some(""),
-            townOrCity = "",
-            postCode = Some(""),
-            countryCode = "GB"
-          ))
+          PPTAddress(addressLine1 = "",
+                     addressLine2 = Some(""),
+                     addressLine3 = Some(""),
+                     townOrCity = "",
+                     postCode = Some(""),
+                     countryCode = "GB"
+          )
+        )
 
         addressDetails.addressLine1 mustBe " "
         addressDetails.addressLine2 mustBe " "

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/AddressDetailsSpec.scala
@@ -25,6 +25,66 @@ class AddressDetailsSpec extends AnyWordSpec with Matchers with RegistrationTest
 
   "AddressDetails" should {
     "map from PPT Address" when {
+      "provided with missing town or city" in {
+        val addressDetails = AddressDetails(
+          PPTAddress(
+            addressLine1 = "Line 1",
+            addressLine2 = None,
+            addressLine3 = Some("Basingstoke"),
+            townOrCity = "",
+            postCode = Some("ZZ1 1ZZ"),
+            countryCode = "GB"
+          )
+        )
+
+        addressDetails.addressLine1 mustBe "Line 1"
+        addressDetails.addressLine2 mustBe "Basingstoke"
+        addressDetails.addressLine3 mustBe None
+        addressDetails.addressLine4 mustBe None
+        addressDetails.postalCode mustBe Some("ZZ1 1ZZ")
+        addressDetails.countryCode mustBe "GB"
+      }
+
+
+      "provided with some empty strings" in {
+        val addressDetails = AddressDetails(
+          PPTAddress(
+            addressLine1 = "Line 1",
+            addressLine2 = Some(""),
+            addressLine3 = Some("Line 3"),
+            townOrCity = "",
+            postCode = Some(""),
+            countryCode = "GB"
+          )
+        )
+
+        addressDetails.addressLine1 mustBe "Line 1"
+        addressDetails.addressLine2 mustBe "Line 3"
+        addressDetails.addressLine3 mustBe None
+        addressDetails.addressLine4 mustBe None
+        addressDetails.postalCode mustBe None
+        addressDetails.countryCode mustBe "GB"
+      }
+
+      "provided with all empty strings" in {
+        val addressDetails = AddressDetails(
+          PPTAddress(
+            addressLine1 = "",
+            addressLine2 = Some(""),
+            addressLine3 = Some(""),
+            townOrCity = "",
+            postCode = Some(""),
+            countryCode = "GB"
+          ))
+
+        addressDetails.addressLine1 mustBe " "
+        addressDetails.addressLine2 mustBe " "
+        addressDetails.addressLine3 mustBe None
+        addressDetails.addressLine4 mustBe None
+        addressDetails.postalCode mustBe None
+        addressDetails.countryCode mustBe "GB"
+      }
+
       "only 'addressLine1', 'townOrCity' and 'PostCode' are available" in {
         val pptAddress =
           PPTAddress(addressLine1 = "addressLine1",

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
@@ -28,13 +28,12 @@ class BusinessCorrespondenceDetailsSpec
   "BusinessCorrespondenceDetails" when {
     "provided with some empty strings" in {
       val details = BusinessCorrespondenceDetails(
-        PPTAddress(
-          addressLine1 = "Line 1",
-          addressLine2 = Some(""),
-          addressLine3 = Some("Line 3"),
-          townOrCity = "",
-          postCode = Some(""),
-          countryCode = "GB"
+        PPTAddress(addressLine1 = "Line 1",
+                   addressLine2 = Some(""),
+                   addressLine3 = Some("Line 3"),
+                   townOrCity = "",
+                   postCode = Some(""),
+                   countryCode = "GB"
         )
       )
 
@@ -48,14 +47,14 @@ class BusinessCorrespondenceDetailsSpec
 
     "provided with all empty strings" in {
       val details = BusinessCorrespondenceDetails(
-        PPTAddress(
-          addressLine1 = "",
-          addressLine2 = Some(""),
-          addressLine3 = Some(""),
-          townOrCity = "",
-          postCode = Some(""),
-          countryCode = "GB"
-        ))
+        PPTAddress(addressLine1 = "",
+                   addressLine2 = Some(""),
+                   addressLine3 = Some(""),
+                   townOrCity = "",
+                   postCode = Some(""),
+                   countryCode = "GB"
+        )
+      )
 
       details.addressLine1 mustBe " "
       details.addressLine2 mustBe " "

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/BusinessCorrespondenceDetailsSpec.scala
@@ -26,6 +26,45 @@ class BusinessCorrespondenceDetailsSpec
     extends AnyWordSpec with Matchers with RegistrationTestData with RegistrationBuilder {
 
   "BusinessCorrespondenceDetails" when {
+    "provided with some empty strings" in {
+      val details = BusinessCorrespondenceDetails(
+        PPTAddress(
+          addressLine1 = "Line 1",
+          addressLine2 = Some(""),
+          addressLine3 = Some("Line 3"),
+          townOrCity = "",
+          postCode = Some(""),
+          countryCode = "GB"
+        )
+      )
+
+      details.addressLine1 mustBe "Line 1"
+      details.addressLine2 mustBe "Line 3"
+      details.addressLine3 mustBe None
+      details.addressLine4 mustBe None
+      details.postalCode mustBe None
+      details.countryCode mustBe "GB"
+    }
+
+    "provided with all empty strings" in {
+      val details = BusinessCorrespondenceDetails(
+        PPTAddress(
+          addressLine1 = "",
+          addressLine2 = Some(""),
+          addressLine3 = Some(""),
+          townOrCity = "",
+          postCode = Some(""),
+          countryCode = "GB"
+        ))
+
+      details.addressLine1 mustBe " "
+      details.addressLine2 mustBe " "
+      details.addressLine3 mustBe None
+      details.addressLine4 mustBe None
+      details.postalCode mustBe None
+      details.countryCode mustBe "GB"
+    }
+
     "building from PPTAddress" should {
       "map address with one line" in {
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddressSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddressSpec.scala
@@ -29,7 +29,6 @@ class PPTAddressSpec extends AnyWordSpec {
 
     "convert from AddressDetails" when {
 
-
       "address has 2 lines" in {
 
         val addr = PPTAddress(

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddressSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/models/PPTAddressSpec.scala
@@ -29,6 +29,7 @@ class PPTAddressSpec extends AnyWordSpec {
 
     "convert from AddressDetails" when {
 
+
       "address has 2 lines" in {
 
         val addr = PPTAddress(


### PR DESCRIPTION
…addresses

### Description of Work carried through

When collapsing the list of address lines down by removing None values the code was ignoring values with empty strings which are still invalid in the submission Schema

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
