### PR TITLE
removed logger prefix that was causing logs to not appear

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/validation/JsonSchemaError.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/validation/JsonSchemaError.scala
@@ -18,14 +18,8 @@ package uk.gov.hmrc.plasticpackagingtaxregistration.models.validation
 
 import play.api.libs.json.{Format, Json}
 
-final case class JsonSchemaError(
-    schemaPath: Option[String],
-    keyword: String,
-    instancePath: String
-  )
+final case class JsonSchemaError(schemaPath: Option[String], keyword: String, instancePath: String)
 
 object JsonSchemaError {
   implicit val formats: Format[JsonSchemaError] = Json.format[JsonSchemaError]
 }
-
-

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/services/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/services/SubscriptionService.scala
@@ -49,7 +49,7 @@ class SubscriptionService @Inject() (
   nonRepudiationService: NonRepudiationService
 )(implicit ec: ExecutionContext)
     extends JSONResponses {
-  private val logger = LoggerFactory.getLogger("application." + getClass.getCanonicalName)
+  private val logger = LoggerFactory.getLogger(getClass.getCanonicalName)
 
   def submit(pptRegistration: Registration, safeId: String, userHeaders: Map[String, String])(
     implicit hc: HeaderCarrier

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/Obfuscation.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/util/Obfuscation.scala
@@ -22,7 +22,7 @@ import java.security.MessageDigest
 import org.slf4j.LoggerFactory
 
 object Obfuscation {
-  private val logger = LoggerFactory.getLogger("application." + getClass.getCanonicalName)
+  private val logger = LoggerFactory.getLogger(getClass.getCanonicalName)
 
   def obfuscate(value: String): String = {
     val result = MessageDigest.getInstance("MD5")

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/validators/PptSchemaValidator.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/validators/PptSchemaValidator.scala
@@ -28,7 +28,7 @@ import scala.util.Try
 
 class PptSchemaValidator(schemaFile: String) {
 
-  private val logger = LoggerFactory.getLogger("application." + getClass.getCanonicalName)
+  private val logger = LoggerFactory.getLogger(getClass.getCanonicalName)
 
   private lazy val schemaFileAsString: Try[String] = {
     Try {

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/validators/PptSchemaValidator.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/validators/PptSchemaValidator.scala
@@ -30,31 +30,33 @@ class PptSchemaValidator(schemaFile: String) {
 
   private val logger = LoggerFactory.getLogger(getClass.getCanonicalName)
 
-  private lazy val schemaFileAsString: Try[String] = {
+  private lazy val schemaFileAsString: Try[String] =
     Try {
       val stream: InputStream = getClass.getResourceAsStream(schemaFile)
       scala.io.Source.fromInputStream(stream).mkString
     }
-  }
 
-  private lazy val circeSchema: Try[io.circe.schema.Schema] = schemaFileAsString.flatMap(io.circe.schema.Schema.loadFromString)
+  private lazy val circeSchema: Try[io.circe.schema.Schema] =
+    schemaFileAsString.flatMap(io.circe.schema.Schema.loadFromString)
 
-  def buildSchemaError(circeError: ValidationError): JsonSchemaError = {
-    JsonSchemaError(
-      circeError.schemaLocation,
-      circeError.keyword,
-      circeError.location
+  def buildSchemaError(circeError: ValidationError): JsonSchemaError =
+    JsonSchemaError(circeError.schemaLocation, circeError.keyword, circeError.location)
 
-    )
-  }
-
-  def validate[T](data: T)(implicit writes: Writes[T]) : Either[NonEmptyList[JsonSchemaError], Unit] = {
+  def validate[T](
+    data: T
+  )(implicit writes: Writes[T]): Either[NonEmptyList[JsonSchemaError], Unit] = {
     val dataJson = Json.toJson(data).toString()
     val result = for {
       js <- io.circe.parser.parse(dataJson).left
-        .map(pf => NonEmptyList.one(ValidationError("SCHEMA_LOAD_ERROR", pf.toString, schemaFile, None)))
+        .map(
+          pf =>
+            NonEmptyList.one(ValidationError("SCHEMA_LOAD_ERROR", pf.toString, schemaFile, None))
+        )
       schema <- circeSchema.toEither.left
-        .map(t => NonEmptyList.one(ValidationError("SCHEMA_LOAD_ERROR", t.getMessage, schemaFile, None)))
+        .map(
+          t =>
+            NonEmptyList.one(ValidationError("SCHEMA_LOAD_ERROR", t.getMessage, schemaFile, None))
+        )
       _ <- schema.validate(js).toEither
     } yield Unit
 
@@ -67,6 +69,7 @@ class PptSchemaValidator(schemaFile: String) {
         Right(Unit)
     }
   }
+
 }
 
 object PptSchemaValidator {

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/validators/PptSchemaValidatorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/validators/PptSchemaValidatorSpec.scala
@@ -43,26 +43,37 @@ class PptSchemaValidatorSpec extends AnyWordSpec with Matchers with Subscription
 
     "creating a subscription with groupSubscriptionFlag as true and partnershipSubscriptionFlag as true" in {
       val data = ukLimitedCompanySubscription.copy(
-                    legalEntityDetails = ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = true, partnershipSubscriptionFlag = true),
-                    groupPartnershipSubscription = Some(GroupPartnershipSubscription(
-                      representativeControl = true,
-                      allMembersControl = true,
-                      Seq(groupPartnershipDetailsRep, groupPartnershipDetailsMember).map(_.copy(regWithoutIDFlag = None))
-                    ))
-                  )
+        legalEntityDetails =
+          ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = true,
+                                                               partnershipSubscriptionFlag = true
+          ),
+        groupPartnershipSubscription = Some(
+          GroupPartnershipSubscription(representativeControl = true,
+                                       allMembersControl = true,
+                                       Seq(groupPartnershipDetailsRep,
+                                           groupPartnershipDetailsMember
+                                       ).map(_.copy(regWithoutIDFlag = None))
+          )
+        )
+      )
 
       PptSchemaValidator.subscriptionValidator.validate(data).isRight mustBe true
     }
 
-
     "creating a subscription with groupSubscriptionFlag as true partnershipSubscriptionFlag as false" in {
       val data = ukLimitedCompanySubscription.copy(
-        legalEntityDetails = ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = true, partnershipSubscriptionFlag = false),
-        groupPartnershipSubscription = Some(GroupPartnershipSubscription(
-          representativeControl = true,
-          allMembersControl = true,
-          Seq(groupPartnershipDetailsRep, groupPartnershipDetailsMember).map(_.copy(regWithoutIDFlag = None))
-        ))
+        legalEntityDetails =
+          ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = true,
+                                                               partnershipSubscriptionFlag = false
+          ),
+        groupPartnershipSubscription = Some(
+          GroupPartnershipSubscription(representativeControl = true,
+                                       allMembersControl = true,
+                                       Seq(groupPartnershipDetailsRep,
+                                           groupPartnershipDetailsMember
+                                       ).map(_.copy(regWithoutIDFlag = None))
+          )
+        )
       )
 
       PptSchemaValidator.subscriptionValidator.validate(data).isRight mustBe true
@@ -70,12 +81,18 @@ class PptSchemaValidatorSpec extends AnyWordSpec with Matchers with Subscription
 
     "creating a subscription with groupSubscriptionFlag as false partnershipSubscriptionFlag as true" in {
       val data = ukLimitedCompanySubscription.copy(
-        legalEntityDetails = ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = false, partnershipSubscriptionFlag = true),
-        groupPartnershipSubscription = Some(GroupPartnershipSubscription(
-          representativeControl = true,
-          allMembersControl = true,
-          Seq(groupPartnershipDetailsRep, groupPartnershipDetailsMember).map(_.copy(regWithoutIDFlag = None))
-        ))
+        legalEntityDetails =
+          ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = false,
+                                                               partnershipSubscriptionFlag = true
+          ),
+        groupPartnershipSubscription = Some(
+          GroupPartnershipSubscription(representativeControl = true,
+                                       allMembersControl = true,
+                                       Seq(groupPartnershipDetailsRep,
+                                           groupPartnershipDetailsMember
+                                       ).map(_.copy(regWithoutIDFlag = None))
+          )
+        )
       )
 
       PptSchemaValidator.subscriptionValidator.validate(data).isRight mustBe true
@@ -83,9 +100,12 @@ class PptSchemaValidatorSpec extends AnyWordSpec with Matchers with Subscription
 
     "creating a subscription with groupSubscriptionFlag  as false and partnershipSubscriptionFlag as false" in {
       val data = ukLimitedCompanySubscription.copy(
-        legalEntityDetails = ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = false, partnershipSubscriptionFlag = false),
-        groupPartnershipSubscription = None)
-
+        legalEntityDetails =
+          ukLimitedCompanySubscription.legalEntityDetails.copy(groupSubscriptionFlag = false,
+                                                               partnershipSubscriptionFlag = false
+          ),
+        groupPartnershipSubscription = None
+      )
 
       PptSchemaValidator.subscriptionValidator.validate(data).isRight mustBe true
     }


### PR DESCRIPTION
### Description of Work carried through
Logging is configured in production at WARN level except for loggers that start with `uk.gov.hmrc.plasticpackagingtaxregistration`. 

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
