### PR TITLE
fallback org type of OverseasCompanyUkBranch for gform subscriptions

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetails.scala
@@ -39,8 +39,7 @@ case class OrganisationDetails(organisationType: Option[String] = None, organisa
           if (partnerTypeNames.contains(organisationType))
             OrgType.PARTNERSHIP
           else
-            OrgType.withName(organisationType)
-
+            OrgType.withNameOpt(organisationType).getOrElse(OrgType.OVERSEAS_COMPANY_UK_BRANCH)
         }
 
       case None =>

--- a/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxregistration/models/OrganisationDetails.scala
@@ -34,6 +34,8 @@ object OrgType extends Enumeration {
   implicit val format: Format[OrgType] =
     Format(Reads.enumNameReads(OrgType), Writes.enumNameWrites)
 
+  def withNameOpt(name: String): Option[Value] = values.find(_.toString == name)
+
 }
 
 case class OrganisationDetails(

--- a/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxregistration/connectors/models/eis/subscription/OrganisationDetailsSpec.scala
@@ -34,6 +34,12 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
       ).organisationTypeDisplayName(isGroup = false) mustBe OrgType.PARTNERSHIP
     }
 
+    "read an organisationType of LIMITED COMPANY as OverseasCompanyUkBranch as fallback for gform reg's" in {
+      OrganisationDetails(organisationType = Some("OverseasCompanyUkBranch"),
+        organisationName = "My organisation"
+      ).organisationTypeDisplayName(isGroup = false) mustBe OrgType.OVERSEAS_COMPANY_UK_BRANCH
+    }
+
     "return partnership organisation type if a partner type enum string is found instead of an organisation type" in {
       OrganisationDetails(organisationType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP.toString),
                           organisationName = "My organisation"


### PR DESCRIPTION
GForm ppt registrations have been manually setting organisationType as 'LIMITED COMPANY'. 

We don't support this type so this change will default organisationType to "OverseasCompanyUkBranch" when it cannot be read into the types we support as is done on the frontend in some places.

Any amendments will take "OverseasCompanyUkBranch" as the organisationType. Not sure if this would result in a failure on an update or not but at least it resolves the user being able to see their account details.